### PR TITLE
Add support for 1M /

### DIFF
--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -25,6 +25,7 @@ export class MessageDecoder {
     this.registerPlugin(new Plugins.Label_H1_M1BPOS(this));
     this.registerPlugin(new Plugins.Label_80(this));
     this.registerPlugin(new Plugins.Label_8E(this));
+    this.registerPlugin(new Plugins.Label_1M_Slash(this));
     this.registerPlugin(new Plugins.Label_SQ(this));
     this.registerPlugin(new Plugins.Label_QP(this));
     this.registerPlugin(new Plugins.Label_QQ(this));

--- a/lib/bin/acars-decoder-test.ts
+++ b/lib/bin/acars-decoder-test.ts
@@ -51,3 +51,6 @@ decode("8E", "EGSS,1618");
 // Label 1M with slash
 decode("1M", `/BA0843/ETA01/230822/LDSP/EGLL/EGSS/2JK0
 1940/EGLL27L/10 `);
+decode("1M", `/AY1416/ETA02/230822/EDDF/EFHK/EETN/2JK0
+1956/EFHK04L/50 
+     /    /    /   /    /   /`);

--- a/lib/bin/acars-decoder-test.ts
+++ b/lib/bin/acars-decoder-test.ts
@@ -47,3 +47,7 @@ decode(
 
 // Label 8E 
 decode("8E", "EGSS,1618");
+
+// Label 1M with slash
+decode("1M", `/BA0843/ETA01/230822/LDSP/EGLL/EGSS/2JK0
+1940/EGLL27L/10 `);

--- a/lib/plugins/Label_1M_Slash.ts
+++ b/lib/plugins/Label_1M_Slash.ts
@@ -22,6 +22,7 @@ export class Label_1M_Slash extends DecoderPlugin {
     if (results) {
       if (options.debug) {
         console.log(`Label 1M ETA: results`);
+        console.log(results);
       }
 
       decodeResult.raw.flight_number = results[0];

--- a/lib/plugins/Label_1M_Slash.ts
+++ b/lib/plugins/Label_1M_Slash.ts
@@ -1,0 +1,72 @@
+import { DecoderPlugin } from '../DecoderPlugin';
+
+export class Label_1M_Slash extends DecoderPlugin {
+  name = 'label-1m-slash';
+
+  qualifiers() { // eslint-disable-line class-methods-use-this
+    return {
+      labels: ["1M"],
+      preambles: ['/'],
+    };
+  }
+
+  decode(message: any, options: any = {}) : any {
+    const decodeResult: any = this.defaultResult;
+    decodeResult.decoder.name = this.name;
+    decodeResult.formatted.description = 'ETA Report';
+    decodeResult.message = message;
+
+    // Style: /BA0843/ETA01/230822/LDSP/EGLL/EGSS/2JK0(NEW LINE)1940/EGLL27L/10 
+    const results = message.text.split(/\n|\//).slice(1); // Split by / and new line
+
+    if (results) {
+      if (options.debug) {
+        console.log(`Label 1M ETA: results`);
+      }
+
+      decodeResult.raw.flight_number = results[0];
+      // results[1]: ETA01 (???)
+      // results[2]: 230822 - UTC date of eta
+      decodeResult.raw.departure_icao = results[3];
+      decodeResult.raw.arrival_icao = results[4];
+      decodeResult.raw.alternate_icao = results[5];
+      // results[6]: 2JK0 (???)
+      // results[7] 1940 - UTC eta
+      decodeResult.raw.arrival_runway = results[8].replace(decodeResult.raw.arrival_icao, ""); // results[8] EGLL27L
+      // results[9]: 10(space) (???)
+
+      decodeResult.raw.arrival_eta = new Date();
+      decodeResult.raw.arrival_eta.setUTCDate(results[2].substring(0, 2), results[2].substring(2, 2), results[2].substring(4, 2));
+      decodeResult.raw.arrival_eta.setUTCHours(results[7].substr(0, 2), results[7].substr(2, 2), 0);
+
+      decodeResult.formatted.items.push({
+        type: 'eta',
+        code: 'ETA',
+        label: 'Estimated Time of Arrival',
+        value: decodeResult.raw.arrival_eta.toGMTString(),
+      });
+
+      decodeResult.formatted.items.push({
+        type: 'destination',
+        code: 'DST',
+        label: 'Destination',
+        value: decodeResult.raw.arrival_icao,
+      });
+
+      decodeResult.formatted.items.push({
+        type: 'origin',
+        code: 'ORG',
+        label: 'Origin',
+        value: decodeResult.raw.departure_icao,
+      });
+
+    }
+
+    decodeResult.decoded = true;
+    decodeResult.decoder.decodeLevel = 'partial';
+
+    return decodeResult;
+  }
+}
+
+export default {};

--- a/lib/plugins/official.ts
+++ b/lib/plugins/official.ts
@@ -12,6 +12,7 @@ export * from './Label_B6';
 export * from './Label_ColonComma';
 export * from './Label_H1_M1BPOS';
 export * from './Label_H1_M1BPRG';
+export * from './Label_1M_Slash';
 export * from './Label_SQ';
 export * from './Label_QR';
 export * from './Label_QP';


### PR DESCRIPTION
Opted to go with a split instead of parsing it out with a regex, made the code a fair bit more readable.

Mostly seen with Finnair A321s, some of their A350s use this.

Etihad 787s also use this label for the same purpose but with a different preamble and very slightly different format, I'll get to that later.

I've not written the test for it yet with the new test framework being used and probably won't get around to doing it for another week or so, so if someone wants to do that before me then feel free.