### PR TITLE
Add GHA to publish on release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@airframes'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -24,5 +24,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
     - run: yarn test


### PR DESCRIPTION
Workflow to release would be:
1. run `git checkout master`
1. run `yarn version <major/minor/patch>`
1. run `git push && git push --tags`
1. Create release from pushed tag on GitHub
1. let the workflow publish to NPM registry