### PR TITLE
change position format for H1-FPN and 44-POS

### DIFF
--- a/lib/plugins/Label_44_POS.test.ts
+++ b/lib/plugins/Label_44_POS.test.ts
@@ -1,0 +1,71 @@
+import { MessageDecoder } from '../MessageDecoder';
+import { Label_44_POS } from './Label_44_POS';
+
+test('matches Label 44 Preamble POS qualifiers', () => {
+  const decoder = new MessageDecoder();
+  const decoderPlugin = new Label_44_POS(decoder);
+
+  expect(decoderPlugin.decode).toBeDefined();
+  expect(decoderPlugin.name).toBe('label-44-pos');
+  expect(decoderPlugin.qualifiers).toBeDefined();
+  expect(decoderPlugin.qualifiers()).toEqual({
+    labels: ['44'],
+    preambles: ['00POS01', '00POS02', '00POS03', 'POS01', 'POS02', 'POS03'],
+  });
+});
+test('decodes Label 44 Preamble POS02 variant 1', () => {
+  const decoder = new MessageDecoder();
+  const decoderPlugin = new Label_44_POS(decoder);
+
+  // https://app.airframes.io/messages/3389060301
+  const text = 'POS02,N38171W077507,319,KJFK,KUZA,0926,0245,0327,004.6';
+  const decodeResult = decoderPlugin.decode({ text: text });
+  console.log(JSON.stringify(decodeResult, null, 2));
+
+  expect(decodeResult.decoded).toBe(true);
+  expect(decodeResult.decoder.decodeLevel).toBe('full');
+  expect(decodeResult.decoder.name).toBe('label-44-pos');
+  expect(decodeResult.formatted.description).toBe('Position Report');
+  expect(decodeResult.message.text).toBe(text);
+  expect(decodeResult.raw.position.latitude).toBe(38.285);
+  expect(decodeResult.raw.position.longitude).toBe(-77.845);
+  expect(decodeResult.raw.flight_level).toBe(319);
+  expect(decodeResult.raw.departure_icao).toBe('KJFK');
+  expect(decodeResult.raw.arrival_icao).toBe('KUZA');
+  expect(decodeResult.raw.current_time).toBe(1727318700000);
+  expect(decodeResult.raw.eta_time).toBe(1727321220000);
+  expect(decodeResult.raw.fuel_in_tons).toBe(4.6);
+  expect(decodeResult.formatted.items.length).toBe(4);
+  expect(decodeResult.formatted.items[0].type).toBe('aircraft_position');
+  expect(decodeResult.formatted.items[0].code).toBe('POS');
+  expect(decodeResult.formatted.items[0].label).toBe('Aircraft Position');
+  expect(decodeResult.formatted.items[0].value).toBe('38.285 N, 77.845 W');
+  expect(decodeResult.formatted.items[1].type).toBe('origin');
+  expect(decodeResult.formatted.items[1].code).toBe('ORG');
+  expect(decodeResult.formatted.items[1].label).toBe('Origin');
+  expect(decodeResult.formatted.items[1].value).toBe('KJFK');
+  expect(decodeResult.formatted.items[2].type).toBe('destination');
+  expect(decodeResult.formatted.items[2].code).toBe('DST');
+  expect(decodeResult.formatted.items[2].label).toBe('Destination');
+  expect(decodeResult.formatted.items[2].value).toBe('KUZA');
+  expect(decodeResult.formatted.items[3].type).toBe('flight_level');
+  expect(decodeResult.formatted.items[3].code).toBe('FL');
+  expect(decodeResult.formatted.items[3].label).toBe('Flight Level');
+  expect(decodeResult.formatted.items[3].value).toBe(319);
+});
+
+// disabled because current parser decodes 'full'
+xtest('decodes Label 44 Preamble POS02 <invalid>', () => {
+  const decoder = new MessageDecoder();
+  const decoderPlugin = new Label_44_POS(decoder);
+
+  const text = 'POS02 Bogus message';
+  const decodeResult = decoderPlugin.decode({ text: text });
+  console.log(JSON.stringify(decodeResult, null, 2));
+
+  expect(decodeResult.decoded).toBe(false);
+  expect(decodeResult.decoder.decodeLevel).toBe('none');
+  expect(decodeResult.decoder.name).toBe('label-44-pos');
+  expect(decodeResult.formatted.description).toBe('Position Report');
+  expect(decodeResult.formatted.items.length).toBe(0);
+});

--- a/lib/plugins/Label_44_POS.ts
+++ b/lib/plugins/Label_44_POS.ts
@@ -29,7 +29,7 @@ export class Label_44_POS extends DecoderPlugin {
         console.log(results.groups);
       }
 
-      decodeResult.raw.position = CoordinateUtils.decodeStringCoordinates(results.groups.unsplit_coords);
+      decodeResult.raw.position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(results.groups.unsplit_coords);
       decodeResult.raw.flight_level = results.groups.flight_level_or_ground == 'GRD' || results.groups.flight_level_or_ground == '***' ? '0' : Number(results.groups.flight_level_or_ground);
       decodeResult.raw.departure_icao = results.groups.departure_icao;
       decodeResult.raw.arrival_icao = results.groups.arrival_icao;
@@ -54,9 +54,9 @@ export class Label_44_POS extends DecoderPlugin {
 
       if(decodeResult.raw.position) {
         decodeResult.formatted.items.push({
-          type: 'position',
+          type: 'aircraft_position',
           code: 'POS' ,
-          label: 'Position',
+          label: 'Aircraft Position',
           value: CoordinateUtils.coordinateString(decodeResult.raw.position),
         });
       }

--- a/lib/plugins/Label_H1_FPN.test.ts
+++ b/lib/plugins/Label_H1_FPN.test.ts
@@ -230,50 +230,6 @@ test('decodes Label H1 Preamble FPN with FN', () => {
   expect(decodeResult.formatted.items[5].value).toBe('BRUSR1 starting at TENTS');
   expect(decodeResult.formatted.items[6].label).toBe('Message Checksum');
   expect(decodeResult.formatted.items[6].value).toBe('0x5d16');
-
-});
-test('decodes Label H1 Preamble FPN with RA', () => {
-  const decoder = new MessageDecoder();
-  const decoderPlugin = new Label_H1_FPN(decoder);
-
-  // https://app.airframes.io/messages/3282851026
-  const text = 'FPN/FNAAL2082/RP:DA:KPHL:AA:KTPA:CR:PHLTPA61:R:09L(19R):D:PHL3:A:MAATY4.HONID:AP:ILS19R..DRAIK,N37080W078590.Q75.GSO..HONID,N31388W084237/RA:DA:KTPA:AA:KMIAFA0F';
-   const decodeResult = decoderPlugin.decode({ text: text });
-  console.log(JSON.stringify(decodeResult, null, 2));
-
-  expect(decodeResult.decoded).toBe(true);
-  expect(decodeResult.decoder.decodeLevel).toBe('full');
-  expect(decodeResult.decoder.name).toBe('label-h1-fpn');
-  expect(decodeResult.raw.flight_number).toBe('AAL2082');
-  expect(decodeResult.formatted.description).toBe('Flight Plan');
-  expect(decodeResult.formatted.items.length).toBe(13);
-  expect(decodeResult.formatted.items[0].label).toBe('Route Status');
-  expect(decodeResult.formatted.items[0].value).toBe('Route Planned');
-  expect(decodeResult.formatted.items[1].label).toBe('Origin');
-  expect(decodeResult.formatted.items[1].value).toBe('KPHL');
-  expect(decodeResult.formatted.items[2].label).toBe('Destination');
-  expect(decodeResult.formatted.items[2].value).toBe('KTPA');
-  expect(decodeResult.formatted.items[3].label).toBe('Company Route');
-  expect(decodeResult.formatted.items[3].value).toBe('PHLTPA61');
-  expect(decodeResult.formatted.items[4].label).toBe('Arrival Runway');
-  expect(decodeResult.formatted.items[4].value).toBe('19R');
-  expect(decodeResult.formatted.items[5].label).toBe('Departure Runway');
-  expect(decodeResult.formatted.items[5].value).toBe('09L');
-  expect(decodeResult.formatted.items[6].label).toBe('Departure Procedure');
-  expect(decodeResult.formatted.items[6].value).toBe('PHL3');
-  expect(decodeResult.formatted.items[7].label).toBe('Arrival Procedure');
-  expect(decodeResult.formatted.items[7].value).toBe('MAATY4 starting at HONID');
-  expect(decodeResult.formatted.items[8].label).toBe('Approach Procedure');
-  expect(decodeResult.formatted.items[8].value).toBe('ILS19R: >> DRAIK(37.133 N, 78.983 W) > Q75 > GSO >> HONID(31.647 N, 84.395 W)');
-  expect(decodeResult.formatted.items[9].label).toBe('Route Status');
-  expect(decodeResult.formatted.items[9].value).toBe('Alternate Route');
-  expect(decodeResult.formatted.items[10].label).toBe('Origin');
-  expect(decodeResult.formatted.items[10].value).toBe('KTPA');
-  expect(decodeResult.formatted.items[11].label).toBe('Destination');
-  expect(decodeResult.formatted.items[11].value).toBe('KMIA');
-  expect(decodeResult.formatted.items[12].label).toBe('Message Checksum');
-  expect(decodeResult.formatted.items[12].value).toBe('0xfa0f');
-
 });
 
 test('decodes Label H1 Preamble #M1BFPN', () => {

--- a/lib/plugins/Label_H1_FPN.test.ts
+++ b/lib/plugins/Label_H1_FPN.test.ts
@@ -81,7 +81,7 @@ test('decodes Label H1 Preamble FPN full flight', () => {
   expect(decodeResult.formatted.items[7].label).toBe('Arrival Procedure');
   expect(decodeResult.formatted.items[7].value).toBe('EAGUL6 starting at ZUN');
   expect(decodeResult.formatted.items[8].label).toBe('Approach Procedure');
-  expect(decodeResult.formatted.items[8].value).toBe('ILS26: >> AIR(40.010 N, 80.490 W) > J110 > BOWRR >> VLA(39.056 N, 89.097 W) >> STL(38.516 N, 90.289 W) >> GIBSN(38.430 N, 92.244 W) >> TYGER(38.410 N, 94.050 W) >> GCK(37.551 N, 100.435 W) >> DIXAN(36.169 N, 105.573 W) >> ZUN(34.579 N, 109.093 W)');
+  expect(decodeResult.formatted.items[8].value).toBe('ILS26: >> AIR(40.017 N, 80.817 W) > J110 > BOWRR >> VLA(39.093 N, 89.162 W) >> STL(38.860 N, 90.482 W) >> GIBSN(38.717 N, 92.407 W) >> TYGER(38.683 N, 94.083 W) >> GCK(37.918 N, 100.725 W) >> DIXAN(36.282 N, 105.955 W) >> ZUN(34.965 N, 109.155 W)');
   expect(decodeResult.formatted.items[9].label).toBe('Message Checksum');
   expect(decodeResult.formatted.items[9].value).toBe('0x293b');
 });
@@ -108,7 +108,7 @@ test('decodes Label H1 Preamble FPN in-flight', () => {
   expect(decodeResult.formatted.items[2].label).toBe('Destination');
   expect(decodeResult.formatted.items[2].value).toBe('KPHX');
   expect(decodeResult.formatted.items[3].label).toBe('Aircraft Route');
-  expect(decodeResult.formatted.items[3].value).toBe('KAYEX(36.292 N, 120.569 W) >> LOSHN(35.509 N, 120.000 W) >> BOILE(34.253 N, 118.016 W) >> BLH(33.358 N, 114.457 W)');
+  expect(decodeResult.formatted.items[3].value).toBe('KAYEX(36.487 N, 120.948 W) >> LOSHN(35.848 N, 120.000 W) >> BOILE(34.422 N, 118.027 W) >> BLH(33.597 N, 114.762 W)');
   expect(decodeResult.formatted.items[4].label).toBe('Message Checksum');
   expect(decodeResult.formatted.items[4].value).toBe('0xddfb');
 });
@@ -196,7 +196,7 @@ test('decodes Label H1 Preamble FPN with SN and TS', () => {
   expect(decodeResult.formatted.items[3].label).toBe('Departure Procedure');
   expect(decodeResult.formatted.items[3].value).toBe('MKK5 starting at KOLEA');
   expect(decodeResult.formatted.items[4].label).toBe('Aircraft Route');
-  expect(decodeResult.formatted.items[4].value).toBe('KOLEA(22.354 N, 155.133 W) >> CLUTS(23.002 N, 154.393 W) > R465 > CINNY(36.109 N, 124.456 W) >> OAL(38.002 N, 117.462 W) > J58 > ILC(38.150 N, 114.237 W) >> EYELO(38.455 N, 110.469 W) >> SAKES(38.500 N, 110.163 W) > J80 > DBL(39.264 N, 106.537 W)');
+  expect(decodeResult.formatted.items[4].value).toBe('KOLEA(22.590 N, 155.222 W) >> CLUTS(23.003 N, 154.655 W) > R465 > CINNY(36.182 N, 124.760 W) >> OAL(38.003 N, 117.770 W) > J58 > ILC(38.250 N, 114.395 W) >> EYELO(38.758 N, 110.782 W) >> SAKES(38.833 N, 110.272 W) > J80 > DBL(39.440 N, 106.895 W)');
   expect(decodeResult.formatted.items[5].label).toBe('Message Checksum');
   expect(decodeResult.formatted.items[5].value).toBe('0xf5e1');
 });
@@ -225,11 +225,54 @@ test('decodes Label H1 Preamble FPN with FN', () => {
   expect(decodeResult.formatted.items[3].label).toBe('Departure Procedure');
   expect(decodeResult.formatted.items[3].value).toBe('SUMMA2 starting at SUMMA');
   expect(decodeResult.formatted.items[4].label).toBe('Aircraft Route');
-  expect(decodeResult.formatted.items[4].value).toBe('SUMMA(46.371 N, 121.593 W) >> LTJ(45.428 N, 121.061 W) >> IMB(44.389 N, 119.427 W) > Q35 >> CORKR(36.050 N, 112.240 W) >> TENTS(35.295 N, 112.271 W)');
+  expect(decodeResult.formatted.items[4].value).toBe('SUMMA(46.618 N, 121.988 W) >> LTJ(45.713 N, 121.102 W) >> IMB(44.648 N, 119.712 W) > Q35 >> CORKR(36.083 N, 112.400 W) >> TENTS(35.492 N, 112.452 W)');
   expect(decodeResult.formatted.items[5].label).toBe('Arrival Procedure');
   expect(decodeResult.formatted.items[5].value).toBe('BRUSR1 starting at TENTS');
   expect(decodeResult.formatted.items[6].label).toBe('Message Checksum');
   expect(decodeResult.formatted.items[6].value).toBe('0x5d16');
+
+});
+test('decodes Label H1 Preamble FPN with RA', () => {
+  const decoder = new MessageDecoder();
+  const decoderPlugin = new Label_H1_FPN(decoder);
+
+  // https://app.airframes.io/messages/3282851026
+  const text = 'FPN/FNAAL2082/RP:DA:KPHL:AA:KTPA:CR:PHLTPA61:R:09L(19R):D:PHL3:A:MAATY4.HONID:AP:ILS19R..DRAIK,N37080W078590.Q75.GSO..HONID,N31388W084237/RA:DA:KTPA:AA:KMIAFA0F';
+   const decodeResult = decoderPlugin.decode({ text: text });
+  console.log(JSON.stringify(decodeResult, null, 2));
+
+  expect(decodeResult.decoded).toBe(true);
+  expect(decodeResult.decoder.decodeLevel).toBe('full');
+  expect(decodeResult.decoder.name).toBe('label-h1-fpn');
+  expect(decodeResult.raw.flight_number).toBe('AAL2082');
+  expect(decodeResult.formatted.description).toBe('Flight Plan');
+  expect(decodeResult.formatted.items.length).toBe(13);
+  expect(decodeResult.formatted.items[0].label).toBe('Route Status');
+  expect(decodeResult.formatted.items[0].value).toBe('Route Planned');
+  expect(decodeResult.formatted.items[1].label).toBe('Origin');
+  expect(decodeResult.formatted.items[1].value).toBe('KPHL');
+  expect(decodeResult.formatted.items[2].label).toBe('Destination');
+  expect(decodeResult.formatted.items[2].value).toBe('KTPA');
+  expect(decodeResult.formatted.items[3].label).toBe('Company Route');
+  expect(decodeResult.formatted.items[3].value).toBe('PHLTPA61');
+  expect(decodeResult.formatted.items[4].label).toBe('Arrival Runway');
+  expect(decodeResult.formatted.items[4].value).toBe('19R');
+  expect(decodeResult.formatted.items[5].label).toBe('Departure Runway');
+  expect(decodeResult.formatted.items[5].value).toBe('09L');
+  expect(decodeResult.formatted.items[6].label).toBe('Departure Procedure');
+  expect(decodeResult.formatted.items[6].value).toBe('PHL3');
+  expect(decodeResult.formatted.items[7].label).toBe('Arrival Procedure');
+  expect(decodeResult.formatted.items[7].value).toBe('MAATY4 starting at HONID');
+  expect(decodeResult.formatted.items[8].label).toBe('Approach Procedure');
+  expect(decodeResult.formatted.items[8].value).toBe('ILS19R: >> DRAIK(37.133 N, 78.983 W) > Q75 > GSO >> HONID(31.647 N, 84.395 W)');
+  expect(decodeResult.formatted.items[9].label).toBe('Route Status');
+  expect(decodeResult.formatted.items[9].value).toBe('Alternate Route');
+  expect(decodeResult.formatted.items[10].label).toBe('Origin');
+  expect(decodeResult.formatted.items[10].value).toBe('KTPA');
+  expect(decodeResult.formatted.items[11].label).toBe('Destination');
+  expect(decodeResult.formatted.items[11].value).toBe('KMIA');
+  expect(decodeResult.formatted.items[12].label).toBe('Message Checksum');
+  expect(decodeResult.formatted.items[12].value).toBe('0xfa0f');
 
 });
 

--- a/lib/plugins/Label_H1_POS.test.ts
+++ b/lib/plugins/Label_H1_POS.test.ts
@@ -334,7 +334,7 @@ test('decodes Label H1 Preamble POS variant 7', () => {
   expect(decodeResult.formatted.items[1].label).toBe('Aircraft Position');
   expect(decodeResult.formatted.items[1].value).toBe('39.277 N, 77.359 W');
   expect(decodeResult.formatted.items[2].label).toBe('Aircraft Route');
-  expect(decodeResult.formatted.items[2].value).toBe('(39.300 N, 77.110 W)@2024-03-03T14:28:00Z > (38.560 N, 77.150 W)@2024-03-03T03:14:30Z > ?');
+  expect(decodeResult.formatted.items[2].value).toBe('(39.500 N, 77.183 W)@2024-03-03T14:28:00Z > (38.933 N, 77.250 W)@2024-03-03T03:14:30Z > ?');
   expect(decodeResult.formatted.items[3].label).toBe('Altitude');
   expect(decodeResult.formatted.items[3].value).toBe('24000 feet');
   expect(decodeResult.formatted.items[4].label).toBe('Outside Air Temperature (C)');
@@ -485,7 +485,7 @@ test('decodes Label H1 Preamble /.POS variant 2', () => {
   expect(decodeResult.formatted.items[1].label).toBe('Altitude');
   expect(decodeResult.formatted.items[1].value).toBe('25000 feet');
   expect(decodeResult.formatted.items[2].label).toBe('Aircraft Route');
-  expect(decodeResult.formatted.items[2].value).toBe('@10:03:16 > (37.131 S, 59.150 W)@10:19:16 > (39.387 S, 60.377 W)');
+  expect(decodeResult.formatted.items[2].value).toBe('@10:03:16 > (37.218 S, 59.250 W)@10:19:16 > (39.645 S, 60.628 W)');
   expect(decodeResult.formatted.items[3].label).toBe('Outside Air Temperature (C)');
   expect(decodeResult.formatted.items[3].value).toBe('-23');
   expect(decodeResult.formatted.items[4].label).toBe('Aircraft Groundspeed');

--- a/lib/utils/coordinate_utils.ts
+++ b/lib/utils/coordinate_utils.ts
@@ -1,4 +1,10 @@
 export class CoordinateUtils {
+  /**
+   * Decode a string of coordinates into an object with latitude and longitude in millidegrees
+   * @param stringCoords - The string of coordinates to decode
+   * 
+   * @returns An object with latitude and longitude properties
+   */
   public static decodeStringCoordinates(stringCoords: String) : {latitude: number, longitude: number} | undefined{ // eslint-disable-line class-methods-use-this
     var results : any = {};
     // format: N12345W123456 or N12345 W123456
@@ -19,6 +25,36 @@ export class CoordinateUtils {
     return results;
   }
 
+    /**
+   * Decode a string of coordinates into an object with latitude and longitude in degrees and decimal minutes
+   * @param stringCoords - The string of coordinates to decode
+   * 
+   * @returns An object with latitude and longitude properties
+   */
+  public static decodeStringCoordinatesDecimalMinutes(stringCoords: String) : {latitude: number, longitude: number} | undefined{ // eslint-disable-line class-methods-use-this
+    var results : any = {};
+    // format: N12345W123456 or N12345 W123456
+    const firstChar = stringCoords.substring(0, 1);
+    let middleChar = stringCoords.substring(6, 7);
+    let longitudeChars = stringCoords.substring(7, 13);
+    if (middleChar ==' ') {
+      middleChar = stringCoords.substring(7, 8);
+      longitudeChars = stringCoords.substring(8, 14);
+    }
+    const latDeg = Math.trunc(Number(stringCoords.substring(1, 6)) / 1000);
+    const latMin = (Number(stringCoords.substring(1, 6)) % 1000) / 10;
+    const lonDeg = Math.trunc(Number(longitudeChars) / 1000);
+    const lonMin = (Number(longitudeChars) % 1000) / 10;
+
+    if ((firstChar === 'N' || firstChar === 'S') && (middleChar === 'W' || middleChar === 'E')) {
+      results.latitude = (latDeg +  (latMin / 60)) * (firstChar === 'S' ? -1 : 1);
+      results.longitude = (lonDeg + (lonMin / 60)) * (middleChar === 'W' ? -1 : 1);
+    } else {
+      return;
+    }
+
+    return results;
+  }
   public static coordinateString(coords: {latitude: number, longitude: number}) : String {
     const latDir = coords.latitude > 0 ? 'N' : 'S';
     const lonDir = coords.longitude > 0 ? 'E' : 'W';

--- a/lib/utils/route_utils.ts
+++ b/lib/utils/route_utils.ts
@@ -48,13 +48,13 @@ export class RouteUtils {
 
         const waypoint = leg.split(',');
         if(waypoint.length ==2) {
-            const position = CoordinateUtils.decodeStringCoordinates(waypoint[1]);
+            const position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(waypoint[1]);
             if(position) {
                 return {name: waypoint[0], latitude: position.latitude, longitude: position.longitude};
             }
         }
         if(leg.length == 13 || leg.length == 14) { //looks like coordinates
-            const position = CoordinateUtils.decodeStringCoordinates(leg);
+            const position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(leg);
             const name = waypoint.length == 2 ? waypoint[0] : '';
             if(position) {
                 return {name: name, latitude: position.latitude, longitude: position.longitude};


### PR DESCRIPTION
format is in degrees with tents of minutes  (DDMMm) instead of millidegrees (DDddd)

fixes https://github.com/airframesio/acars-decoder-typescript/issues/125