### PR TITLE
Add missing tests: Label_SQ and Label_20_POS

### DIFF
--- a/lib/plugins/Label_20_POS.test.ts
+++ b/lib/plugins/Label_20_POS.test.ts
@@ -1,0 +1,39 @@
+import { MessageDecoder } from '../MessageDecoder';
+import { Label_20_POS } from './Label_20_POS';
+
+describe('Label_20_POS', () => {
+  const decoder = new MessageDecoder();
+  const plugin = new Label_20_POS(decoder);
+
+  const decode = (text: string) => {
+    return plugin.decode({ text });
+  };
+
+  it('decodes POS variation with 11 fields (coordinates only required)', () => {
+    const text = 'POSN38160W077075,,211733,360,OTT,212041,,N42,19689,40,544';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(true);
+    expect(res.decoder.decodeLevel).toBe('full');
+    expect(res.formatted.description).toBe('Position Report');
+    expect(res.raw.preamble).toBe('POS');
+  });
+
+  it('decodes POS variation with 5 fields (coordinates only)', () => {
+    const text = 'POSN38160W077075,,211733,360,OTT';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(true);
+    expect(res.decoder.decodeLevel).toBe('full');
+    expect(res.formatted.description).toBe('Position Report');
+  });
+
+  it('marks unknown variation as not decoded', () => {
+    const text = 'POSUNKNOWN';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(false);
+    expect(res.decoder.decodeLevel).toBe('none');
+    expect(res.formatted.description).toBe('Position Report');
+  });
+});

--- a/lib/plugins/Label_SQ.test.ts
+++ b/lib/plugins/Label_SQ.test.ts
@@ -1,0 +1,71 @@
+import { MessageDecoder } from '../MessageDecoder';
+import { Label_SQ } from './Label_SQ';
+
+describe('Label_SQ', () => {
+  const decoder = new MessageDecoder();
+  const plugin = new Label_SQ(decoder);
+
+  const decode = (text: string) => {
+    return plugin.decode({ text });
+  };
+
+  it('decodes version 2 ARINC ground station squitter with coordinates and frequency', () => {
+    const text = 'V2AA' + '0' + '1X' + 'A' + 'JFK' + 'KJFK' + '3' + '4075' + 'N' + '7398' + 'W' + 'V136975' + '/extra';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(true);
+    expect(res.decoder.name).toBe('label-sq');
+    expect(res.decoder.decodeLevel).toBe('full');
+
+    expect(res.raw.preamble).toBe(text.substring(0, 4));
+    expect(res.raw.version).toBe('2');
+    expect(res.raw.network).toBe('A');
+
+    expect(res.raw.groundStation).toBeDefined();
+    expect(res.raw.groundStation.number).toBe('3');
+    expect(res.raw.groundStation.iataCode).toBe('JFK');
+    expect(res.raw.groundStation.icaoCode).toBe('KJFK');
+
+    expect(res.raw.groundStation.coordinates.latitude).toBeCloseTo(40.75, 5);
+    expect(res.raw.groundStation.coordinates.longitude).toBeCloseTo(-73.98, 5);
+
+    expect(res.raw.vdlFrequency).toBeCloseTo(136.975, 6);
+
+    const items = res.formatted.items;
+    expect(items.find(i => i.code === 'NETT')?.value).toBe('ARINC');
+    expect(items.find(i => i.code === 'VER')?.value).toBe('2');
+    expect(items.find(i => i.code === 'GNDSTN')?.value).toBe('KJFK3');
+    expect(items.find(i => i.code === 'IATA')?.value).toBe('JFK');
+    expect(items.find(i => i.code === 'ICAO')?.value).toBe('KJFK');
+    expect(items.find(i => i.code === 'VDLFRQ')?.value).toContain('136.975');
+  });
+
+  it('maps SITA network and handles absence of regex match gracefully', () => {
+    const text = 'V2AS' + '0' + 'XXXXNOTMATCHING';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(true);
+    expect(res.raw.version).toBe('2');
+    expect(res.raw.network).toBe('S');
+
+    const items = res.formatted.items;
+    expect(items.find(i => i.code === 'NETT')?.value).toBe('SITA');
+    expect(items.find(i => i.code === 'VER')?.value).toBe('2');
+
+    expect(res.raw.groundStation).toBeUndefined();
+    expect(res.raw.vdlFrequency).toBeUndefined();
+  });
+
+  it('handles non-version-2 payloads (no regex path)', () => {
+    const text = 'V1AA' + 'WHATEVER';
+    const res = decode(text);
+
+    expect(res.decoded).toBe(true);
+    expect(res.raw.version).toBe('1');
+    expect(res.raw.network).toBe('A');
+
+    const items = res.formatted.items;
+    expect(items.find(i => i.code === 'NETT')?.value).toBe('ARINC');
+    expect(items.find(i => i.code === 'VER')?.value).toBe('1');
+  });
+});


### PR DESCRIPTION
# Add Missing Tests Across Three Repositories

## Summary

This PR adds comprehensive test coverage to previously untested or low-coverage sections across three Airframes repositories:

- **acars-decoder-typescript**: Added tests for `Label_SQ` (13.33% → 90.83% coverage) and `Label_20_POS` (31.74% → 82.53% coverage) plugins
- **api-server**: Added comprehensive unit tests for `FlightNumber` utility class covering IATA/ICAO parsing, validation, and edge cases  
- **api-fastapi**: Introduced pytest configuration and initial hermetic import tests with proper mocking

The tests focus on core parsing logic, validation edge cases, and error handling scenarios that were previously untested.

## Review & Testing Checklist for Human

- [ ] **Run all test suites locally** - Especially api-fastapi tests (I encountered pg_config environment issues preventing full validation)
- [ ] **Validate ARINC message format accuracy** - The Label_SQ test constructs specific ARINC ground station squitter messages; verify these match real-world message formats
- [ ] **Check FlightNumber edge cases** - Review that the test cases cover realistic airline codes and flight numbers from your actual data
- [ ] **Verify no regressions** - One pre-existing test in api-server (zitadel-jwt.strategy.spec.ts) was failing due to assertion mismatch; ensure this doesn't impact the new tests
- [ ] **Test mocking behavior** - The api-fastapi tests mock ClickHouse and Redis dependencies; verify the mocking accurately reflects real usage

**Recommended test plan**: Run `npm test`, `yarn test`, and `poetry run pytest` respectively in each repo to ensure all tests pass in your environment.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "acars-decoder-typescript"
        LabelSQ["lib/plugins/Label_SQ.ts"]:::context
        LabelSQTest["lib/plugins/Label_SQ.test.ts"]:::major-edit
        Label20POS["lib/plugins/Label_20_POS.ts"]:::context  
        Label20POSTest["lib/plugins/Label_20_POS.test.ts"]:::major-edit
        MessageDecoder["lib/MessageDecoder.ts"]:::context
    end

    subgraph "api-server"
        FlightNumber["src/utils/flight_number.ts"]:::context
        FlightNumberTest["src/utils/flight_number.spec.ts"]:::major-edit
        ZitadelStrategy["src/auth/zitadel-jwt.strategy.ts"]:::context
    end

    subgraph "api-fastapi"  
        AppMain["app/main.py"]:::context
        TestMain["tests/test_main.py"]:::major-edit
        TestImports["tests/test_imports.py"]:::major-edit
        PytestIni["pytest.ini"]:::major-edit
    end

    LabelSQTest -->|"tests decode logic"| LabelSQ
    Label20POSTest -->|"tests position parsing"| Label20POS
    FlightNumberTest -->|"tests IATA/ICAO parsing"| FlightNumber
    TestMain -->|"mocks dependencies"| AppMain

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Coverage improvements**: Label_SQ went from 13.33% to 90.83% coverage, Label_20_POS from 31.74% to 82.53%
- **Environment issue**: api-fastapi tests couldn't be fully validated due to missing PostgreSQL development headers (pg_config) preventing psycopg2 installation
- **Pre-existing test failure**: api-server has one failing test in zitadel-jwt.strategy.spec.ts due to assertion message mismatch (not related to new changes)
- **Test approach**: Used existing test patterns and mocking strategies from each codebase to maintain consistency

**Session requested by**: Kevin Elliott (@kevinelliott)  
**Devin session**: https://app.devin.ai/sessions/144ecd3792924403b4cd3c823b89d108