### PR TITLE
chore(node): support Node >=18; test 18/20/22/24; dev on Node 24 types

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        # build against all active LTS and latest node
-        node-version: [18.x, 20.x, latest]
+        # build against all active LTS and current stable node
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.6.19",
       "license": "UNLICENSED",
       "dependencies": {
-        "@types/node": "^22.13.10",
         "base85": "^3.1.0",
         "minizlib": "^3.0.1"
       },
@@ -23,12 +22,16 @@
         "@babel/preset-typescript": "^7.26.0",
         "@types/jest": "^29.5.14",
         "@types/minizlib": "^2.1.7",
+        "@types/node": "^24.2.1",
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2567,12 +2570,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
-      "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6274,9 +6278,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "build": "tsup",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/airframesio/acars-decoder-typescript.git"
@@ -27,7 +30,6 @@
   "author": "Kevin Elliott <kevin@welikeinc.com>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@types/node": "^22.13.10",
     "base85": "^3.1.0",
     "minizlib": "^3.0.1"
   },
@@ -37,6 +39,7 @@
     "@babel/preset-typescript": "^7.26.0",
     "@types/jest": "^29.5.14",
     "@types/minizlib": "^2.1.7",
+    "@types/node": "^24.2.1",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.6",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["index.ts"],
-  format: ["cjs", "esm"], // Build for commonJS and ESmodules
-  dts: true, // Generate declaration file (.d.ts)
+  format: ["cjs", "esm"],
+  dts: true,
   splitting: false,
   sourcemap: true,
   clean: true,
+  target: "node18",
 });


### PR DESCRIPTION
# chore(node): support Node >=18; test 18/20/22/24; dev on Node 24 types

## Summary

Updates the Node.js support matrix to explicitly support Node >=18 while allowing development with the latest stable Node 24 types. This addresses the dependabot PR that wanted to bump `@types/node` to v24 by implementing a compatibility strategy that doesn't force Node 24 types onto library consumers.

**Key Changes:**
- Added `engines.node: ">=18"` to explicitly communicate runtime support
- Moved `@types/node` from `dependencies` → `devDependencies` and bumped `^22.13.10` → `^24.2.1`
- Set `tsup` target to `"node18"` to ensure compiled output stays compatible with Node 18+
- Updated CI matrix from `[18.x, 20.x, latest]` → `[18.x, 20.x, 22.x, 24.x]` for deterministic testing

This preserves broad runtime compatibility (Node 18+) while allowing the development team to use modern Node 24 typings for better DX.

## Review & Testing Checklist for Human
- [ ] **Verify CI passes on all Node versions (18.x, 20.x, 22.x, 24.x)** - This is the critical validation that our compatibility strategy works
- [ ] **Test package import/usage on Node 18** - Create a small test script importing the built package on Node 18 to ensure no runtime compatibility regressions
- [ ] **Confirm tsup target "node18" produces compatible output** - Inspect `dist/` files to ensure no Node 19+ syntax is emitted
- [ ] **Validate that moving @types/node to devDependencies doesn't break consumers** - Check that library users don't depend on transitive Node types

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    PJ["package.json<br/>engines + deps"]:::major-edit
    TC["tsup.config.ts<br/>target: node18"]:::major-edit
    CI[".github/workflows/<br/>yarn-test.yml<br/>matrix: 18/20/22/24"]:::major-edit
    
    LIB["lib/**/*.ts<br/>Source Code"]:::context
    DIST["dist/**<br/>Built Output"]:::context
    
    PJ -->|"declares runtime<br/>support >=18"| LIB
    TC -->|"compiles for<br/>Node 18+"| DIST
    CI -->|"validates on<br/>4 Node versions"| DIST
    LIB -->|"built by tsup"| DIST
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- The package-lock.json was updated due to the @types/node version bump (from v22 → v24)
- Local tests passed with `npm install && npm run build && npm test` 
- This maintains the dual CJS/ESM output format and doesn't change any decoding logic
- Session: https://app.devin.ai/sessions/84a3ed2bc8094c3bb8918c56940dfa28
- Requested by: Kevin Elliott (@kevinelliott)