### PR TITLE
ci: add non-required Node 'latest' job; docs: add CHANGELOG entry for Node support updates

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -16,8 +16,8 @@ jobs:
 
     strategy:
       matrix:
-        # build against all active LTS and current stable node
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        # build against all active LTS and current stable node; include "latest" as an extra, non-required signal
+        node-version: [18.x, 20.x, 22.x, 24.x, latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Node.js support and CI:
+  - Declare runtime support: Node >=18 in `package.json` engines
+  - Build target via tsup set to `node18` to ensure compatibility across Node 18/20/22/24
+  - CI matrix updated to test Node 18.x, 20.x, 22.x, 24.x; added an extra job for Node “latest” (non-required) for early signal
+  - Development types use latest stable `@types/node` (currently v24) as a devDependency
+
+- Fixes:
+  - Add explicit `Buffer` imports from `node:buffer` in `lib/utils/miam.ts` and `lib/plugins/Label_H1_OHMA.ts`


### PR DESCRIPTION
# ci: add non-required Node 'latest' job; docs: add CHANGELOG entry for Node support updates

## Summary

This is a follow-up to the previous Node.js support matrix update. Adds a Node "latest" job to CI for early signal on upcoming Node versions, plus creates a CHANGELOG.md to document the recent Node support policy changes.

**Changes:**
- **CI Enhancement**: Added `latest` to the Node version matrix in `.github/workflows/yarn-test.yml` alongside existing 18.x/20.x/22.x/24.x jobs
- **Documentation**: Created `CHANGELOG.md` with entry documenting the Node ≥18 support policy, tsup node18 targeting, Buffer import fixes, and CI matrix updates from the previous PR

## Review & Testing Checklist for Human

- [ ] **Verify "latest" job is non-required**: Confirm that if the Node "latest" job fails, it won't block PRs (check branch protection rules if any exist)
- [ ] **CHANGELOG accuracy**: Review that the changelog entry correctly summarizes the recent Node support changes 
- [ ] **CI matrix still works**: Ensure the required Node versions (18.x, 20.x, 22.x, 24.x) continue to pass as expected

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A[".github/workflows/yarn-test.yml"]:::major-edit
    B["CHANGELOG.md"]:::major-edit
    C["CI Matrix Jobs"]:::context
    D["Node 18.x"]:::context
    E["Node 20.x"]:::context
    F["Node 22.x"]:::context
    G["Node 24.x"]:::context
    H["Node latest"]:::minor-edit
    
    A --> C
    C --> D
    C --> E
    C --> F
    C --> G
    C --> H
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This builds on PR #276 which established the Node ≥18 support policy and was already merged
- The "latest" job provides early warning for potential issues with upcoming Node versions but shouldn't block development
- No functional code changes - purely CI and documentation updates

**Session Info**: 
- Link to Devin run: https://app.devin.ai/sessions/84a3ed2bc8094c3bb8918c56940dfa28
- Requested by: Kevin Elliott (@kevinelliott)