### PR TITLE
Add Label 22 Compact OOOI decoder plugin (Virgin Atlantic)

### DIFF
--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -78,6 +78,7 @@ const pluginClasses = [
   Plugins.Label_QQ,
   Plugins.Label_QR,
   Plugins.Label_QS,
+  Plugins.Label_22_Compact_OOOI,
 ];
 
 export class MessageDecoder {

--- a/lib/plugins/Label_22_Compact_OOOI.ts
+++ b/lib/plugins/Label_22_Compact_OOOI.ts
@@ -1,0 +1,144 @@
+import { DecoderPlugin } from '../DecoderPlugin';
+import { DecodeResult, Message, Options } from '../DecoderPluginInterface';
+import { ResultFormatter } from '../utils/result_formatter';
+import { DateTimeUtils } from '../DateTimeUtils';
+
+/**
+ * Label 22 — Compact OOOI-style Event Report
+ *
+ * A terse 13-character aircraft-downlink variant seen on some Virgin
+ * Atlantic traffic. Most likely an OFF (wheels-off / takeoff) event report
+ * per the analyst's interpretation — but the compact form carries no
+ * explicit OFF/ON/IN/OUT prefix, so this plugin surfaces the airport,
+ * date, and time without claiming a specific OOOI event.
+ *
+ * Wire format:
+ *
+ *   EGLL 0824 1432 0
+ *   |    |    |    |
+ *   |    |    |    └ Trailing flag / status byte (raw, undocumented)
+ *   |    |    └───── Time HHMM UTC (14:32 UTC)
+ *   |    └────────── Date MMDD (08 = August, 24 = day)
+ *   └─────────────── ICAO airport code (4 chars)
+ *
+ * This plugin matches only the exact 13-character shape `<ICAO:4><MMDD:4>
+ * <HHMM:4><flag:1>` — other Label-22 sub-formats (OFF-prefixed variants,
+ * POS position reports) are handled by sibling plugins.
+ */
+export class Label_22_Compact_OOOI extends DecoderPlugin {
+  name = 'label-22-compact-oooi';
+
+  qualifiers() {
+    return {
+      labels: ['22'],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const decodeResult = this.initResult(
+      message,
+      'Compact OOOI-style Event Report',
+    );
+
+    const text = (message.text || '').trim();
+    if (!text) {
+      this.setDecodeLevel(decodeResult, false);
+      return decodeResult;
+    }
+
+    const m = text.match(
+      /^(?<icao>[A-Z]{4})(?<mm>\d{2})(?<dd>\d{2})(?<hh>\d{2})(?<min>\d{2})(?<flag>\d)$/,
+    );
+    if (!m?.groups) {
+      this.setDecodeLevel(decodeResult, false);
+      return decodeResult;
+    }
+
+    const { icao, mm, dd, hh, min, flag } = m.groups;
+    const monthN = Number(mm);
+    const dayN = Number(dd);
+    const hourN = Number(hh);
+    const minN = Number(min);
+
+    // Validate ranges before committing — a valid MMDD+HHMM avoids false
+    // positives on arbitrary 13-digit strings.
+    if (
+      monthN < 1 ||
+      monthN > 12 ||
+      dayN < 1 ||
+      dayN > 31 ||
+      hourN > 23 ||
+      minN > 59
+    ) {
+      this.setDecodeLevel(decodeResult, false);
+      return decodeResult;
+    }
+
+    const months = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    const monthName = months[monthN - 1];
+
+    // ── raw ──
+    ResultFormatter.departureAirport(decodeResult, icao);
+    decodeResult.raw.month = monthN;
+    decodeResult.raw.day = dayN;
+    decodeResult.raw.time_hhmm = `${hh}:${min}`;
+    decodeResult.raw.trailing_flag = flag;
+    ResultFormatter.timestamp(
+      decodeResult,
+      DateTimeUtils.convertHHMMSSToTod(`${hh}${min}00`),
+    );
+
+    // ── formatted (one row per field) ──
+    decodeResult.formatted.items.unshift(
+      {
+        type: 'message_type',
+        code: 'MSGTYP',
+        label: 'Message Type',
+        value:
+          'Compact OOOI-style Event Report (likely OFF / wheels-off)',
+      },
+      {
+        type: 'airport',
+        code: 'APT',
+        label: 'Airport',
+        value: icao,
+      },
+    );
+    decodeResult.formatted.items.push(
+      {
+        type: 'date',
+        code: 'DATE',
+        label: 'Date (MMDD)',
+        value: `${monthName} ${dayN} (${mm}/${dd})`,
+      },
+      {
+        type: 'time',
+        code: 'TIME',
+        label: 'Time (UTC, HHMM)',
+        value: `${hh}:${min}`,
+      },
+      {
+        type: 'trailing_flag',
+        code: 'FLAG',
+        label: 'Trailing Flag',
+        value: flag,
+      },
+    );
+
+    this.setDecodeLevel(decodeResult, true, 'full');
+    return decodeResult;
+  }
+}

--- a/lib/plugins/official.ts
+++ b/lib/plugins/official.ts
@@ -64,3 +64,4 @@ export * from './Label_QR';
 export * from './Label_QP';
 export * from './Label_QS';
 export * from './Label_QQ';
+export * from './Label_22_Compact_OOOI';


### PR DESCRIPTION
Adds a decoder for a terse 13-character label-22 variant seen on Virgin Atlantic traffic — likely an OFF (wheels-off/takeoff) event report.

### Wire format
```
EGLL082414320
|    |   |   ||
|    |   |   |└ Flag / status byte (raw)
|    |   |   └ Minute (HHMM)
|    |   └──── Hour
|    └──────── Date (MMDD)
└───────────── ICAO airport code
```

Coexists with existing `Label_22_OFF` / `Label_22_POS` via strict shape guard.

`npm run build` passes.