### PR TITLE
Add Label 3L Position decoder plugin (Jetstar)

### DIFF
--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -78,6 +78,7 @@ const pluginClasses = [
   Plugins.Label_QQ,
   Plugins.Label_QR,
   Plugins.Label_QS,
+  Plugins.Label_3L_Position,
 ];
 
 export class MessageDecoder {

--- a/lib/plugins/Label_3L_Position.ts
+++ b/lib/plugins/Label_3L_Position.ts
@@ -1,0 +1,104 @@
+import { DecoderPlugin } from '../DecoderPlugin';
+import { DecodeResult, Message, Options } from '../DecoderPluginInterface';
+import { ResultFormatter } from '../utils/result_formatter';
+import { DateTimeUtils } from '../DateTimeUtils';
+
+/**
+ * Label 3L — Position Report (Jetstar variant)
+ *
+ * Compact in-flight position downlink: hemisphere-prefixed decimal-degree
+ * latitude/longitude plus a UTC HHMM timestamp. No altitude, speed, or
+ * heading is carried.
+ *
+ * Wire format:
+ *
+ *   S 21.940 / E 147.806  / UTC 2146
+ *   | |        | |          |     |
+ *   | |        | |          |     └─ Time, HHMM (UTC)
+ *   | |        | |          └─────── Literal "UTC" tag (preceded by " /")
+ *   | |        | └────────────────── Longitude in decimal degrees
+ *   | |        └──────────────────── Longitude hemisphere (E/W)
+ *   | └──────────────────────────── Latitude in decimal degrees
+ *   └─────────────────────────────── Latitude hemisphere (N/S)
+ *
+ * The single space and the surrounding spaces around `/` are tolerated.
+ */
+export class Label_3L_Position extends DecoderPlugin {
+  name = 'label-3l-position';
+
+  qualifiers() {
+    return {
+      labels: ['3L'],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const decodeResult = this.initResult(message, 'Position Report');
+
+    const text = (message.text || '').trim();
+    if (!text) {
+      this.setDecodeLevel(decodeResult, false);
+      return decodeResult;
+    }
+
+    // Hemisphere + decimal degrees + UTC HHMM
+    const regex =
+      /^(?<latH>[NS])\s*(?<lat>\d+(?:\.\d+)?)\s*\/\s*(?<lonH>[EW])\s*(?<lon>\d+(?:\.\d+)?)\s*\/\s*UTC\s+(?<time>\d{4})\s*$/;
+    const m = text.match(regex);
+    if (!m?.groups) {
+      this.setDecodeLevel(decodeResult, false);
+      return decodeResult;
+    }
+
+    const { latH, lat, lonH, lon, time } = m.groups;
+    const latitude = Number(lat) * (latH === 'S' ? -1 : 1);
+    const longitude = Number(lon) * (lonH === 'W' ? -1 : 1);
+    const hh = time.substring(0, 2);
+    const mm = time.substring(2, 4);
+
+    // Use the standard position helper so the generic chip renderer
+    // (and any downstream tooling that looks at raw.position) picks it up
+    ResultFormatter.position(decodeResult, { latitude, longitude });
+    decodeResult.raw.message_timestamp = DateTimeUtils.convertHHMMSSToTod(time + '00');
+
+    decodeResult.formatted.items.unshift(
+      {
+        type: 'message_type',
+        code: 'MSGTYP',
+        label: 'Message Type',
+        value: 'Position Report (Jetstar 3L — lat/lon + UTC)',
+      },
+      {
+        type: 'direction',
+        code: 'DIR',
+        label: 'Direction',
+        value: 'Downlink (aircraft → ground)',
+      },
+    );
+
+    // Show the hemispheres explicitly for readability
+    decodeResult.formatted.items.push(
+      {
+        type: 'lat_decoded',
+        code: 'LAT',
+        label: 'Latitude',
+        value: `${lat}° ${latH === 'S' ? 'South' : 'North'} (${latitude})`,
+      },
+      {
+        type: 'lon_decoded',
+        code: 'LON',
+        label: 'Longitude',
+        value: `${lon}° ${lonH === 'W' ? 'West' : 'East'} (${longitude})`,
+      },
+      {
+        type: 'time',
+        code: 'TIME',
+        label: 'Time (UTC)',
+        value: `${hh}:${mm} UTC`,
+      },
+    );
+
+    this.setDecodeLevel(decodeResult, true, 'full');
+    return decodeResult;
+  }
+}

--- a/lib/plugins/official.ts
+++ b/lib/plugins/official.ts
@@ -64,3 +64,4 @@ export * from './Label_QR';
 export * from './Label_QP';
 export * from './Label_QS';
 export * from './Label_QQ';
+export * from './Label_3L_Position';


### PR DESCRIPTION
Adds a decoder for the slash-delimited lat/lon/UTC label-3L position report.

### Wire format
```
N 12.345 / E 123.456 / UTC 1430
```

`npm run build` passes.