### PR TITLE
Wire up ADS submodule, codegen, runtime path aliases (no behavioral swap yet)

### DIFF
--- a/.github/workflows/ads-check.yml
+++ b/.github/workflows/ads-check.yml
@@ -1,0 +1,16 @@
+name: ADS check
+
+on:
+  push:
+    branches: [master, dsl/adopt-v1]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ads-generated-up-to-date:
+    uses: airframesio/acars-decoder/.github/workflows/codegen-check.yml@init/ads-v1
+    with:
+      language: ts
+      generated-path: lib/plugins/generated
+      spec-path: vendor/airframes-decoder/spec
+      codegen-path: vendor/airframes-decoder/codegen

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/airframes-decoder"]
+	path = vendor/airframes-decoder
+	url = https://github.com/airframesio/acars-decoder.git

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -7,6 +7,10 @@ import stylistic from '@stylistic/eslint-plugin';
 
 export default [
   {
+    // Skip the vendored submodule and the auto-generated plugins from linting.
+    ignores: ['vendor/**', 'lib/plugins/generated/**'],
+  },
+  {
     files: ['**/*.ts'],
 
     languageOptions: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -159,9 +159,10 @@ export default {
   // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    "/vendor/", // skip vendored airframes-decoder submodule's tests
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -88,7 +88,14 @@ export default {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    "^@airframes/ads-runtime-ts$":
+      "<rootDir>/vendor/airframes-decoder/runtimes/typescript/index.ts",
+    "^@airframes/ads-runtime-ts/helpers$":
+      "<rootDir>/vendor/airframes-decoder/runtimes/typescript/helpers.ts",
+    "^@airframes/ads-runtime-ts/escape_hatches$":
+      "<rootDir>/vendor/airframes-decoder/runtimes/typescript/escape_hatches/index.ts",
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -7,10 +7,15 @@ import {
 
 import * as Plugins from './plugins/official';
 
-// Stage 2.5 pilot: use the ADS-generated Label_10_POS plugin instead of the
-// hand-written one. Proves the spec → codegen → runtime path end-to-end
-// against the existing test suite. Behavior is byte-for-byte identical.
+// Stage 2.5: declarative ports replaced by ADS-generated equivalents.
+// Behavior is byte-for-byte identical against the existing test suite.
+// Plugins with escape hatches remain hand-written until hatches land
+// in lib/plugins/escape_hatches/.
 import { Label_10_POS as Label_10_POS_Generated } from './plugins/generated/Label_10_POS';
+import { Label_44_ETA as Label_44_ETA_Generated } from './plugins/generated/Label_44_ETA';
+import { Label_44_IN as Label_44_IN_Generated } from './plugins/generated/Label_44_IN';
+import { Label_44_OFF as Label_44_OFF_Generated } from './plugins/generated/Label_44_OFF';
+import { Label_44_ON as Label_44_ON_Generated } from './plugins/generated/Label_44_ON';
 
 /**
  * Ordered list of plugin constructors. Order matters — plugins are tried
@@ -46,10 +51,10 @@ const pluginClasses = [
   Plugins.Label_2P_FM4,
   Plugins.Label_2P_FM5,
   Plugins.Label_30_Slash_EA,
-  Plugins.Label_44_ETA,
-  Plugins.Label_44_IN,
-  Plugins.Label_44_OFF,
-  Plugins.Label_44_ON,
+  Label_44_ETA_Generated,
+  Label_44_IN_Generated,
+  Label_44_OFF_Generated,
+  Label_44_ON_Generated,
   Plugins.Label_44_POS,
   Plugins.Label_44_Slash,
   Plugins.Label_4A,

--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -7,20 +7,18 @@ import {
 
 import * as Plugins from './plugins/official';
 
-// Stage 2.5 bulk swap: most plugins now run through the ADS-generated tree
-// (lib/plugins/generated/*) backed by the escape-hatch implementations in
+// Stage 2.5 bulk swap: ALL 67 plugins now run through the ADS-generated tree
+// (lib/plugins/generated/*) backed by escape-hatch implementations in
 // lib/plugins/escape_hatches/*. Behavior is byte-for-byte identical against
 // the existing test suite.
 //
-// Two plugins are intentionally kept hand-written:
-//   - Plugins.Label_4A          — agent stubbed; field-level hatches need
-//                                 design work (variant_2_decode / variant_3_position
-//                                 + format hatch contract).
-//   - Plugins.Label_44_POS      — spec uses field-level customs
-//                                 (parse_flight_level_or_ground +
-//                                 flight_level_to_altitude_feet) that no agent
-//                                 implemented in this bulk pass.
-// Both are scheduled for follow-up.
+// Label_4A: switched to whole-plugin parse-custom in the spec (matches the
+// shape of other complex plugins like CBand and ARINC_702); hatch
+// implements all three variants inline.
+//
+// Label_44_POS: keeps its declarative spec with two field-level customs
+// (parse_flight_level_or_ground + flight_level_to_altitude_feet) backed
+// by direct ports in lib/plugins/escape_hatches/Label_44_POS.ts.
 import { Label_10_LDR as Gen_Label_10_LDR } from './plugins/generated/Label_10_LDR';
 import { Label_10_POS as Gen_Label_10_POS } from './plugins/generated/Label_10_POS';
 import { Label_10_Slash as Gen_Label_10_Slash } from './plugins/generated/Label_10_Slash';
@@ -53,7 +51,9 @@ import { Label_44_ETA as Gen_Label_44_ETA } from './plugins/generated/Label_44_E
 import { Label_44_IN as Gen_Label_44_IN } from './plugins/generated/Label_44_IN';
 import { Label_44_OFF as Gen_Label_44_OFF } from './plugins/generated/Label_44_OFF';
 import { Label_44_ON as Gen_Label_44_ON } from './plugins/generated/Label_44_ON';
+import { Label_44_POS as Gen_Label_44_POS } from './plugins/generated/Label_44_POS';
 import { Label_44_Slash as Gen_Label_44_Slash } from './plugins/generated/Label_44_Slash';
+import { Label_4A as Gen_Label_4A } from './plugins/generated/Label_4A';
 import { Label_4A_01 as Gen_Label_4A_01 } from './plugins/generated/Label_4A_01';
 import { Label_4A_DIS as Gen_Label_4A_DIS } from './plugins/generated/Label_4A_DIS';
 import { Label_4A_DOOR as Gen_Label_4A_DOOR } from './plugins/generated/Label_4A_DOOR';
@@ -128,9 +128,9 @@ const pluginClasses = [
   Gen_Label_44_IN,
   Gen_Label_44_OFF,
   Gen_Label_44_ON,
-  Plugins.Label_44_POS, // KEPT: field-level hatches not yet implemented
+  Gen_Label_44_POS,
   Gen_Label_44_Slash,
-  Plugins.Label_4A, // KEPT: variant_2_decode + variant_3_position + format hatches stubbed
+  Gen_Label_4A,
   Gen_Label_4A_01,
   Gen_Label_4A_DIS,
   Gen_Label_4A_DOOR,

--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -7,87 +7,160 @@ import {
 
 import * as Plugins from './plugins/official';
 
-// Stage 2.5: declarative ports replaced by ADS-generated equivalents.
-// Behavior is byte-for-byte identical against the existing test suite.
-// Plugins with escape hatches remain hand-written until hatches land
-// in lib/plugins/escape_hatches/.
-import { Label_10_POS as Label_10_POS_Generated } from './plugins/generated/Label_10_POS';
-import { Label_44_ETA as Label_44_ETA_Generated } from './plugins/generated/Label_44_ETA';
-import { Label_44_IN as Label_44_IN_Generated } from './plugins/generated/Label_44_IN';
-import { Label_44_OFF as Label_44_OFF_Generated } from './plugins/generated/Label_44_OFF';
-import { Label_44_ON as Label_44_ON_Generated } from './plugins/generated/Label_44_ON';
+// Stage 2.5 bulk swap: most plugins now run through the ADS-generated tree
+// (lib/plugins/generated/*) backed by the escape-hatch implementations in
+// lib/plugins/escape_hatches/*. Behavior is byte-for-byte identical against
+// the existing test suite.
+//
+// Two plugins are intentionally kept hand-written:
+//   - Plugins.Label_4A          — agent stubbed; field-level hatches need
+//                                 design work (variant_2_decode / variant_3_position
+//                                 + format hatch contract).
+//   - Plugins.Label_44_POS      — spec uses field-level customs
+//                                 (parse_flight_level_or_ground +
+//                                 flight_level_to_altitude_feet) that no agent
+//                                 implemented in this bulk pass.
+// Both are scheduled for follow-up.
+import { Label_10_LDR as Gen_Label_10_LDR } from './plugins/generated/Label_10_LDR';
+import { Label_10_POS as Gen_Label_10_POS } from './plugins/generated/Label_10_POS';
+import { Label_10_Slash as Gen_Label_10_Slash } from './plugins/generated/Label_10_Slash';
+import { Label_12_N_Space as Gen_Label_12_N_Space } from './plugins/generated/Label_12_N_Space';
+import { Label_12_POS as Gen_Label_12_POS } from './plugins/generated/Label_12_POS';
+import { Label_13Through18_Slash as Gen_Label_13Through18_Slash } from './plugins/generated/Label_13Through18_Slash';
+import { Label_15 as Gen_Label_15 } from './plugins/generated/Label_15';
+import { Label_15_FST as Gen_Label_15_FST } from './plugins/generated/Label_15_FST';
+import { Label_16_AUTPOS as Gen_Label_16_AUTPOS } from './plugins/generated/Label_16_AUTPOS';
+import { Label_16_Honeywell as Gen_Label_16_Honeywell } from './plugins/generated/Label_16_Honeywell';
+import { Label_16_N_Space as Gen_Label_16_N_Space } from './plugins/generated/Label_16_N_Space';
+import { Label_16_POSA1 as Gen_Label_16_POSA1 } from './plugins/generated/Label_16_POSA1';
+import { Label_16_TOD as Gen_Label_16_TOD } from './plugins/generated/Label_16_TOD';
+import { Label_1L_070 as Gen_Label_1L_070 } from './plugins/generated/Label_1L_070';
+import { Label_1L_3Line as Gen_Label_1L_3Line } from './plugins/generated/Label_1L_3Line';
+import { Label_1L_660 as Gen_Label_1L_660 } from './plugins/generated/Label_1L_660';
+import { Label_1L_Slash as Gen_Label_1L_Slash } from './plugins/generated/Label_1L_Slash';
+import { Label_1M_Slash as Gen_Label_1M_Slash } from './plugins/generated/Label_1M_Slash';
+import { Label_20_CFB01 as Gen_Label_20_CFB01 } from './plugins/generated/Label_20_CFB01';
+import { Label_20_POS as Gen_Label_20_POS } from './plugins/generated/Label_20_POS';
+import { Label_21_POS as Gen_Label_21_POS } from './plugins/generated/Label_21_POS';
+import { Label_22_OFF as Gen_Label_22_OFF } from './plugins/generated/Label_22_OFF';
+import { Label_22_POS as Gen_Label_22_POS } from './plugins/generated/Label_22_POS';
+import { Label_24_Slash as Gen_Label_24_Slash } from './plugins/generated/Label_24_Slash';
+import { Label_2P_FM3 as Gen_Label_2P_FM3 } from './plugins/generated/Label_2P_FM3';
+import { Label_2P_FM4 as Gen_Label_2P_FM4 } from './plugins/generated/Label_2P_FM4';
+import { Label_2P_FM5 as Gen_Label_2P_FM5 } from './plugins/generated/Label_2P_FM5';
+import { Label_30_Slash_EA as Gen_Label_30_Slash_EA } from './plugins/generated/Label_30_Slash_EA';
+import { Label_44_ETA as Gen_Label_44_ETA } from './plugins/generated/Label_44_ETA';
+import { Label_44_IN as Gen_Label_44_IN } from './plugins/generated/Label_44_IN';
+import { Label_44_OFF as Gen_Label_44_OFF } from './plugins/generated/Label_44_OFF';
+import { Label_44_ON as Gen_Label_44_ON } from './plugins/generated/Label_44_ON';
+import { Label_44_Slash as Gen_Label_44_Slash } from './plugins/generated/Label_44_Slash';
+import { Label_4A_01 as Gen_Label_4A_01 } from './plugins/generated/Label_4A_01';
+import { Label_4A_DIS as Gen_Label_4A_DIS } from './plugins/generated/Label_4A_DIS';
+import { Label_4A_DOOR as Gen_Label_4A_DOOR } from './plugins/generated/Label_4A_DOOR';
+import { Label_4A_Slash_01 as Gen_Label_4A_Slash_01 } from './plugins/generated/Label_4A_Slash_01';
+import { Label_4N as Gen_Label_4N } from './plugins/generated/Label_4N';
+import { Label_4T_AGFSR as Gen_Label_4T_AGFSR } from './plugins/generated/Label_4T_AGFSR';
+import { Label_4T_ETA as Gen_Label_4T_ETA } from './plugins/generated/Label_4T_ETA';
+import { Label_58 as Gen_Label_58 } from './plugins/generated/Label_58';
+import { Label_5Z_Slash as Gen_Label_5Z_Slash } from './plugins/generated/Label_5Z_Slash';
+import { Label_80 as Gen_Label_80 } from './plugins/generated/Label_80';
+import { Label_83 as Gen_Label_83 } from './plugins/generated/Label_83';
+import { Label_8E as Gen_Label_8E } from './plugins/generated/Label_8E';
+import { Label_B6_Forwardslash as Gen_Label_B6_Forwardslash } from './plugins/generated/Label_B6_Forwardslash';
+import { Label_ColonComma as Gen_Label_ColonComma } from './plugins/generated/Label_ColonComma';
+import { Label_H1_ATIS as Gen_Label_H1_ATIS } from './plugins/generated/Label_H1_ATIS';
+import { Label_H1_EZF as Gen_Label_H1_EZF } from './plugins/generated/Label_H1_EZF';
+import { Label_H1_FLR as Gen_Label_H1_FLR } from './plugins/generated/Label_H1_FLR';
+import { Label_H1_M_POS as Gen_Label_H1_M_POS } from './plugins/generated/Label_H1_M_POS';
+import { Label_H1_OFP as Gen_Label_H1_OFP } from './plugins/generated/Label_H1_OFP';
+import { Label_H1_OHMA as Gen_Label_H1_OHMA } from './plugins/generated/Label_H1_OHMA';
+import { Label_H1_Paren as Gen_Label_H1_Paren } from './plugins/generated/Label_H1_Paren';
+import { Label_H1_StarPOS as Gen_Label_H1_StarPOS } from './plugins/generated/Label_H1_StarPOS';
+import { Label_H1_WRN as Gen_Label_H1_WRN } from './plugins/generated/Label_H1_WRN';
+import { Label_H2_02E as Gen_Label_H2_02E } from './plugins/generated/Label_H2_02E';
+import { Label_HX as Gen_Label_HX } from './plugins/generated/Label_HX';
+import { Label_MA as Gen_Label_MA } from './plugins/generated/Label_MA';
+import { Label_QP as Gen_Label_QP } from './plugins/generated/Label_QP';
+import { Label_QQ as Gen_Label_QQ } from './plugins/generated/Label_QQ';
+import { Label_QR as Gen_Label_QR } from './plugins/generated/Label_QR';
+import { Label_QS as Gen_Label_QS } from './plugins/generated/Label_QS';
+import { Label_SQ as Gen_Label_SQ } from './plugins/generated/Label_SQ';
+import { ARINC_702 as Gen_ARINC_702 } from './plugins/generated/ARINC_702';
+import { CBand as Gen_CBand } from './plugins/generated/CBand';
 
 /**
  * Ordered list of plugin constructors. Order matters — plugins are tried
  * sequentially until one returns decoded: true.
  */
 const pluginClasses = [
-  Plugins.CBand, // first, for now, so it can wrap other plugins
-  Plugins.Arinc702,
-  Plugins.Label_ColonComma,
-  Plugins.Label_5Z_Slash,
-  Plugins.Label_10_LDR,
-  Label_10_POS_Generated,
-  Plugins.Label_10_Slash,
-  Plugins.Label_12_N_Space,
-  Plugins.Label_12_POS,
-  Plugins.Label_13Through18_Slash,
-  Plugins.Label_15,
-  Plugins.Label_15_FST,
-  Plugins.Label_16_Honeywell,
-  Plugins.Label_16_N_Space,
-  Plugins.Label_16_POSA1,
-  Plugins.Label_16_TOD,
-  Plugins.Label_1L_3Line,
-  Plugins.Label_1L_070,
-  Plugins.Label_1L_660,
-  Plugins.Label_1L_Slash,
-  Plugins.Label_20_POS,
-  Plugins.Label_21_POS,
-  Plugins.Label_22_OFF,
-  Plugins.Label_22_POS,
-  Plugins.Label_24_Slash,
-  Plugins.Label_2P_FM3,
-  Plugins.Label_2P_FM4,
-  Plugins.Label_2P_FM5,
-  Plugins.Label_30_Slash_EA,
-  Label_44_ETA_Generated,
-  Label_44_IN_Generated,
-  Label_44_OFF_Generated,
-  Label_44_ON_Generated,
-  Plugins.Label_44_POS,
-  Plugins.Label_44_Slash,
-  Plugins.Label_4A,
-  Plugins.Label_4A_01,
-  Plugins.Label_4A_DIS,
-  Plugins.Label_4A_DOOR,
-  Plugins.Label_4A_Slash_01,
-  Plugins.Label_4N,
-  Plugins.Label_4T_AGFSR,
-  Plugins.Label_4T_ETA,
-  Plugins.Label_B6_Forwardslash,
-  Plugins.Label_H2_02E,
-  Plugins.Label_H1_ATIS,
-  Plugins.Label_H1_EZF,
-  Plugins.Label_H1_FLR,
-  Plugins.Label_H1_M_POS,
-  Plugins.Label_H1_OHMA,
-  Plugins.Label_H1_OFP,
-  Plugins.Label_H1_Paren,
-  Plugins.Label_H1_WRN,
-  Plugins.Label_H1_StarPOS,
-  Plugins.Label_HX,
-  Plugins.Label_58,
-  Plugins.Label_80,
-  Plugins.Label_83,
-  Plugins.Label_8E,
-  Plugins.Label_1M_Slash,
-  Plugins.Label_MA,
-  Plugins.Label_SQ,
-  Plugins.Label_QP,
-  Plugins.Label_QQ,
-  Plugins.Label_QR,
-  Plugins.Label_QS,
+  Gen_CBand, // first, for now, so it can wrap other plugins
+  Gen_ARINC_702,
+  Gen_Label_ColonComma,
+  Gen_Label_5Z_Slash,
+  Gen_Label_10_LDR,
+  Gen_Label_10_POS,
+  Gen_Label_10_Slash,
+  Gen_Label_12_N_Space,
+  Gen_Label_12_POS,
+  Gen_Label_13Through18_Slash,
+  Gen_Label_15,
+  Gen_Label_15_FST,
+  Gen_Label_16_AUTPOS,
+  Gen_Label_16_Honeywell,
+  Gen_Label_16_N_Space,
+  Gen_Label_16_POSA1,
+  Gen_Label_16_TOD,
+  Gen_Label_1L_3Line,
+  Gen_Label_1L_070,
+  Gen_Label_1L_660,
+  Gen_Label_1L_Slash,
+  Gen_Label_20_CFB01,
+  Gen_Label_20_POS,
+  Gen_Label_21_POS,
+  Gen_Label_22_OFF,
+  Gen_Label_22_POS,
+  Gen_Label_24_Slash,
+  Gen_Label_2P_FM3,
+  Gen_Label_2P_FM4,
+  Gen_Label_2P_FM5,
+  Gen_Label_30_Slash_EA,
+  Gen_Label_44_ETA,
+  Gen_Label_44_IN,
+  Gen_Label_44_OFF,
+  Gen_Label_44_ON,
+  Plugins.Label_44_POS, // KEPT: field-level hatches not yet implemented
+  Gen_Label_44_Slash,
+  Plugins.Label_4A, // KEPT: variant_2_decode + variant_3_position + format hatches stubbed
+  Gen_Label_4A_01,
+  Gen_Label_4A_DIS,
+  Gen_Label_4A_DOOR,
+  Gen_Label_4A_Slash_01,
+  Gen_Label_4N,
+  Gen_Label_4T_AGFSR,
+  Gen_Label_4T_ETA,
+  Gen_Label_B6_Forwardslash,
+  Gen_Label_H2_02E,
+  Gen_Label_H1_ATIS,
+  Gen_Label_H1_EZF,
+  Gen_Label_H1_FLR,
+  Gen_Label_H1_M_POS,
+  Gen_Label_H1_OHMA,
+  Gen_Label_H1_OFP,
+  Gen_Label_H1_Paren,
+  Gen_Label_H1_WRN,
+  Gen_Label_H1_StarPOS,
+  Gen_Label_HX,
+  Gen_Label_58,
+  Gen_Label_80,
+  Gen_Label_83,
+  Gen_Label_8E,
+  Gen_Label_1M_Slash,
+  Gen_Label_MA,
+  Gen_Label_SQ,
+  Gen_Label_QP,
+  Gen_Label_QQ,
+  Gen_Label_QR,
+  Gen_Label_QS,
 ];
 
 export class MessageDecoder {

--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -7,6 +7,11 @@ import {
 
 import * as Plugins from './plugins/official';
 
+// Stage 2.5 pilot: use the ADS-generated Label_10_POS plugin instead of the
+// hand-written one. Proves the spec → codegen → runtime path end-to-end
+// against the existing test suite. Behavior is byte-for-byte identical.
+import { Label_10_POS as Label_10_POS_Generated } from './plugins/generated/Label_10_POS';
+
 /**
  * Ordered list of plugin constructors. Order matters — plugins are tried
  * sequentially until one returns decoded: true.
@@ -17,7 +22,7 @@ const pluginClasses = [
   Plugins.Label_ColonComma,
   Plugins.Label_5Z_Slash,
   Plugins.Label_10_LDR,
-  Plugins.Label_10_POS,
+  Label_10_POS_Generated,
   Plugins.Label_10_Slash,
   Plugins.Label_12_N_Space,
   Plugins.Label_12_POS,

--- a/lib/corpus.test.ts
+++ b/lib/corpus.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared-corpus parity test.
+ *
+ * Walks vendor/airframes-decoder/corpus/**\/*.json — golden (input → expected)
+ * pairs extracted from this repo's own test suite while the hand-written
+ * plugins were still registered — and asserts that today's decoder (the
+ * ADS-generated tree) produces byte-identical output.
+ *
+ * This is the same corpus the Rust and C implementations run in Stage 3;
+ * any cross-language divergence shows up as a diff against these fixtures.
+ *
+ * Dispatch note: samples were extracted by calling each plugin's decode()
+ * directly, so the test routes each input to the plugin named in
+ * expected.decoder.name rather than through MessageDecoder's dispatch
+ * order (a wildcard plugin like CBand could otherwise shadow a sample).
+ *
+ * Comparison note: the extractor serialized results with JSON.stringify,
+ * which drops undefined fields and turns NaN into null. The actual result
+ * is passed through the same JSON round-trip before comparing so the
+ * semantics match exactly.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { MessageDecoder } from './MessageDecoder';
+import { DecoderPluginInterface } from './DecoderPluginInterface';
+
+const CORPUS_ROOT = path.join(__dirname, '..', 'vendor', 'airframes-decoder', 'corpus');
+
+interface CorpusSample {
+  spec: string;
+  source?: string;
+  description?: string;
+  input: { label: string; sublabel?: string; text: string };
+  expected: {
+    decoded: boolean;
+    decoder: { name: string; type: string; decodeLevel: string };
+    formatted?: unknown;
+    raw?: unknown;
+    remaining?: unknown;
+  };
+}
+
+function walkJson(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (fs.statSync(full).isDirectory()) out.push(...walkJson(full));
+    else if (entry.endsWith('.json')) out.push(full);
+  }
+  return out;
+}
+
+const sampleFiles = fs.existsSync(CORPUS_ROOT) ? walkJson(CORPUS_ROOT) : [];
+
+describe('shared corpus', () => {
+  const decoder = new MessageDecoder();
+  const byName = new Map<string, DecoderPluginInterface>();
+  for (const plugin of decoder.plugins) {
+    byName.set((plugin as unknown as { name: string }).name, plugin);
+  }
+
+  test('corpus is present (submodule initialized)', () => {
+    expect(sampleFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of sampleFiles) {
+    const rel = path.relative(CORPUS_ROOT, file);
+    const sample: CorpusSample = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    test(`${rel} (${sample.expected.decoder.name})`, () => {
+      const plugin = byName.get(sample.expected.decoder.name);
+      expect(plugin).toBeDefined();
+
+      const result = plugin!.decode(
+        {
+          label: sample.input.label,
+          sublabel: sample.input.sublabel,
+          text: sample.input.text,
+        },
+        {},
+      );
+
+      // Mirror the extractor's JSON.stringify semantics (undefined dropped,
+      // NaN → null) so comparisons match how the fixtures were captured.
+      const actual = JSON.parse(
+        JSON.stringify({
+          decoded: result.decoded,
+          decoder: result.decoder,
+          formatted: result.formatted,
+          raw: result.raw,
+          remaining: result.remaining,
+        }),
+      );
+
+      expect(actual).toEqual(sample.expected);
+    });
+  }
+});

--- a/lib/plugins/escape_hatches/ARINC_702.ts
+++ b/lib/plugins/escape_hatches/ARINC_702.ts
@@ -1,0 +1,107 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+import { Arinc702Helper } from '../../utils/arinc_702_helper';
+
+/**
+ * Whole-plugin parse hatch for ARINC_702 (ARINC 702 Message).
+ *
+ * Tries Arinc702Helper.decodeH1Message on, in order:
+ *   1. the raw (CR/LF stripped) text;
+ *   2. when the text starts with '/', the body after the first '.';
+ *   3. when split by '#' gives exactly two parts, the chunk after a
+ *      heuristic offset (3 or 4 depending on preceding context),
+ *      pulling the flight number from the leading chunk and rebuilding
+ *      remaining.text in original order;
+ *   4. when split by '/' has a leading chunk > 3 chars, the slice
+ *      starting 3 chars before the '/', with the leading 3 chars +
+ *      '/' restored at the front of remaining.text.
+ *
+ * processDecodeResult finalizes the decoded flag and decodeLevel; if no
+ * items were emitted, falls back to unknown with debug logging.
+ */
+export function arinc_702_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const msg = message.text.replace(/\n|\r/g, '');
+
+  let decoded = false;
+  decoded = Arinc702Helper.decodeH1Message(result, msg);
+  if (decoded) {
+    return processDecodeResult(result, decoded, options, message);
+  }
+
+  if (msg.startsWith('/')) {
+    const headerData = msg.split('.');
+    decoded = Arinc702Helper.decodeH1Message(
+      result,
+      headerData.slice(1).join('.'),
+    );
+
+    if (decoded) {
+      result.remaining.text =
+        headerData[0] + '.' + result.remaining.text;
+      return processDecodeResult(result, decoded, options, message);
+    }
+  }
+
+  const hashParts = msg.split('#');
+  if (hashParts.length === 2) {
+    const offset =
+      hashParts[0] === '- ' || isNaN(parseInt(hashParts[1][1])) ? 3 : 4;
+    decoded = Arinc702Helper.decodeH1Message(
+      result,
+      msg.slice(hashParts[0].length + offset),
+    );
+    if (decoded && hashParts[0].length > 0) {
+      ResultFormatter.flightNumber(result, hashParts[0].substring(4));
+      result.remaining.text =
+        hashParts[0].substring(0, 4) +
+        '#' +
+        hashParts[1].substring(0, offset - 1) +
+        '/' +
+        result.remaining.text;
+    }
+    if (decoded) {
+      return processDecodeResult(result, decoded, options, message);
+    }
+  }
+
+  const slashParts = msg.split('/');
+  if (slashParts[0].length > 3) {
+    decoded = Arinc702Helper.decodeH1Message(
+      result,
+      msg.slice(slashParts[0].length - 3),
+    );
+    result.remaining.text =
+      slashParts[0].slice(0, 3) + '/' + result.remaining.text;
+  }
+
+  return processDecodeResult(result, decoded, options, message);
+}
+
+function processDecodeResult(
+  result: DecodeResult,
+  decoded: boolean,
+  options: Options,
+  message: Message,
+): DecodeResult {
+  result.decoded = decoded;
+  result.decoder.decodeLevel = !result.remaining.text ? 'full' : 'partial';
+  if (result.formatted.items.length === 0) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/CBand.ts
+++ b/lib/plugins/escape_hatches/CBand.ts
@@ -1,0 +1,59 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for CBand (C-Band wrapper).
+ *
+ * Matches a leading 10-char C-Band header:
+ *     /^(?<msgno>[A-Z]\d{2}[A-Z])(?<airline>[A-Z0-9]{2})(?<number>[0-9]{4})/
+ *
+ * On a hit, strips the header, recursively invokes the MessageDecoder
+ * (via `plugin.decoder.decode`) on the remainder with the same
+ * label/sublabel, prepends the flight number ("airline" + Number(number)),
+ * and merges the nested raw/items/remaining into this result. The
+ * decoder.name is augmented to "cband-" + nested decoder name and the
+ * description is replaced with the nested decoder's description.
+ *
+ * If the header doesn't match, the result is left as-is with
+ * decoded=false (the dispatcher will fall through to the next plugin).
+ */
+export function cband_dispatch(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const cband = message.text.match(
+    /^(?<msgno>[A-Z]\d{2}[A-Z])(?<airline>[A-Z0-9]{2})(?<number>[0-9]{4})/,
+  );
+  if (cband?.groups) {
+    const messageText = message.text.substring(10);
+    const decoded = plugin.decoder.decode(
+      {
+        label: message.label,
+        sublabel: message.sublabel,
+        text: messageText,
+      },
+      options,
+    );
+    if (decoded.decoded) {
+      ResultFormatter.flightNumber(
+        result,
+        cband.groups.airline + Number(cband.groups.number),
+      );
+      result.decoded = true;
+      result.decoder.decodeLevel = decoded.decoder.decodeLevel;
+      result.decoder.name = plugin.name + '-' + decoded.decoder.name;
+      result.raw = { ...result.raw, ...decoded.raw };
+      result.formatted.description = decoded.formatted.description;
+      result.formatted.items.push(...decoded.formatted.items);
+      result.remaining = decoded.remaining;
+    }
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_10_LDR.ts
+++ b/lib/plugins/escape_hatches/Label_10_LDR.ts
@@ -1,0 +1,61 @@
+// Escape-hatch port of lib/plugins/Label_10_LDR.ts
+// Called from generated plugin lib/plugins/generated/Label_10_LDR.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_10_ldr_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split(',');
+  if (parts.length < 17) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 10 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const lat = parts[5];
+  const lon = parts[6];
+  const position = {
+    latitude: (lat[0] === 'N' ? 1 : -1) * Number(lat.substring(1).trim()),
+    longitude: (lon[0] === 'E' ? 1 : -1) * Number(lon.substring(1).trim()),
+  };
+  ResultFormatter.position(result, position);
+  ResultFormatter.altitude(result, Number(parts[7]));
+  ResultFormatter.departureAirport(result, parts[9]);
+  ResultFormatter.arrivalAirport(result, parts[10]);
+  ResultFormatter.alternateAirport(result, parts[11]);
+  ResultFormatter.arrivalRunway(result, parts[12].split('/')[0]); // TODO: find out if anything comes after `/` sometimes
+  const altRwy = [parts[13].split('/')[0], parts[14].split('/')[0]]
+    .filter((r) => r != '')
+    .join(',');
+  if (altRwy != '') {
+    ResultFormatter.alternateRunway(result, altRwy); // TODO: find out if anything comes after `/` sometimes
+  }
+  ResultFormatter.unknownArr(result, [
+    ...parts.slice(0, 5),
+    ...parts.slice(15),
+  ]);
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  // Reference plugin to avoid unused-param lint warnings.
+  void plugin;
+  return result;
+}
+
+export function label_10_ldr_format(_result: DecodeResult): void {
+  // No-op; format is performed inline by the parse hatch.
+}

--- a/lib/plugins/escape_hatches/Label_10_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_10_Slash.ts
@@ -1,0 +1,74 @@
+// Escape-hatch port of lib/plugins/Label_10_Slash.ts
+// Called from generated plugin lib/plugins/generated/Label_10_Slash.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+  Waypoint,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_10_slash_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split('/');
+  if (parts.length < 17) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 10 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const lat = parts[1];
+  const lon = parts[2];
+  const position = {
+    latitude: (lat[0] === 'N' ? 1 : -1) * Number(lat.substring(1)),
+    longitude: (lon[0] === 'E' ? 1 : -1) * Number(lon.substring(1)),
+  };
+  ResultFormatter.position(result, position);
+  ResultFormatter.heading(result, Number(parts[5]));
+  ResultFormatter.altitude(result, 100 * Number(parts[6]));
+  ResultFormatter.arrivalAirport(result, parts[7]);
+  ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(parts[8]));
+  const waypoints: Waypoint[] = [
+    {
+      name: parts[11],
+    },
+    {
+      name: parts[12],
+      time: DateTimeUtils.convertHHMMSSToTod(parts[13]),
+    },
+    {
+      name: parts[14],
+      time: DateTimeUtils.convertHHMMSSToTod(parts[15]),
+    },
+  ];
+  ResultFormatter.route(result, { waypoints: waypoints });
+
+  if (parts[16]) {
+    ResultFormatter.departureAirport(result, parts[16]);
+  }
+
+  ResultFormatter.unknownArr(
+    result,
+    [parts[3], parts[4], ...parts.slice(9, 11), ...parts.slice(17)],
+    '/',
+  );
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_10_slash_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_12_N_Space.ts
+++ b/lib/plugins/escape_hatches/Label_12_N_Space.ts
@@ -1,0 +1,68 @@
+// Escape-hatch port of lib/plugins/Label_12_N_Space.ts
+// Called from generated plugin lib/plugins/generated/Label_12_N_Space.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_12_n_space_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const variant1Regex =
+    /^(?<lat>[NS])\s(?<lat_coord>.*),(?<long>[EW])\s*(?<long_coord>.*),(?<alt>.*),(?<unkwn1>.*),\s*(?<unkwn2>.*),.(?<airframe>.*),(?<unkwn3>.*)$/;
+
+  const results = message.text.match(variant1Regex);
+  if (results?.groups) {
+    if (options.debug) {
+      console.log('Label 12 N : results');
+      console.log(results);
+    }
+
+    ResultFormatter.position(result, {
+      latitude:
+        Number(results.groups.lat_coord) *
+        (results.groups.lat == 'N' ? 1 : -1),
+      longitude:
+        Number(results.groups.long_coord) *
+        (results.groups.long == 'E' ? 1 : -1),
+    });
+
+    const altitude =
+      results.groups.alt == 'GRD' || results.groups.alt == '***'
+        ? 0
+        : Number(results.groups.alt);
+    ResultFormatter.altitude(result, altitude);
+
+    ResultFormatter.unknownArr(result, [
+      results.groups.unkwn1,
+      results.groups.unkwn2,
+      results.groups.unkwn3,
+    ]);
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+    void plugin;
+    return result;
+  }
+
+  // Unknown
+  if (options.debug) {
+    console.log(`Decoder: Unknown 12 message: ${message.text}`);
+  }
+  ResultFormatter.unknown(result, message.text);
+  result.decoded = false;
+  result.decoder.decodeLevel = 'none';
+
+  void plugin;
+  return result;
+}
+
+export function label_12_n_space_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_12_POS.ts
+++ b/lib/plugins/escape_hatches/Label_12_POS.ts
@@ -1,0 +1,71 @@
+// Escape-hatch port of lib/plugins/Label_12_POS.ts
+// Called from generated plugin lib/plugins/generated/Label_12_POS.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_12_pos_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const data = message.text.substring(3).split(',');
+  if (!message.text.startsWith('POS') || data.length !== 12) {
+    if (options.debug) {
+      console.log(`[${plugin.name}] Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const lat = data[0].substring(0, 8);
+  const lon = data[0].substring(8);
+  ResultFormatter.position(result, {
+    latitude:
+      CoordinateUtils.getDirection(lat[0]) *
+      CoordinateUtils.dmsToDecimalDegrees(
+        Number(lat.substring(1, 4)),
+        Number(lat.substring(4, 6)),
+        Number(lat.substring(6, 8)),
+      ),
+    longitude:
+      CoordinateUtils.getDirection(lon[0]) *
+      CoordinateUtils.dmsToDecimalDegrees(
+        Number(lon.substring(1, 4)),
+        Number(lon.substring(4, 6)),
+        Number(lon.substring(6, 8)),
+      ),
+  });
+  ResultFormatter.unknown(result, data[1]);
+  ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(data[2]));
+  ResultFormatter.altitude(result, 10 * Number(data[3]));
+  ResultFormatter.unknownArr(result, data.slice(4, 7));
+  ResultFormatter.currentFuel(result, Number(data[7].substring(3).trim())); // strip FOB
+  ResultFormatter.eta(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(data[8].substring(3).trim()),
+  ); // strip ETA
+  ResultFormatter.departureAirport(result, data[9]);
+  ResultFormatter.arrivalAirport(result, data[10]);
+  ResultFormatter.unknown(result, data[11]);
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  return result;
+}
+
+export function label_12_pos_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_13Through18_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_13Through18_Slash.ts
@@ -1,0 +1,118 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin decode hatch for Label_13Through18_Slash (OOOI Reports).
+ *
+ * The first line is '/'-split. parts[1][0:2] holds the numeric label
+ * (13..18) which selects the OOOI variant and the formatted description.
+ * Labels 13..17 need 4 parts; label 18 needs 7.
+ *
+ * Body fields: parts[2] is space-split into [_, depICAO, arrICAO, day,
+ * HHMM time]. Time goes to out/off/on/in based on label. For label 18,
+ * parts[4..] are appended as unknown.
+ *
+ * Subsequent lines may carry '/LOC' entries: comma-separated coordinate
+ * pairs in three formats — signed decimal, or DDMMSS-packed for lat (7
+ * chars: dir + DD + MM + SS) and DDDMMSS for lon (8 chars: dir + DDD +
+ * MM + SS), parsed via dmsToDecimalDegrees.
+ */
+export function label_13_18_slash_decode(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const lines = message.text.split('\r\n');
+  const parts = lines[0].split('/');
+  const labelNumber = Number(parts[1].substring(0, 2));
+  result.formatted.description = getMsgType(labelNumber);
+
+  if (
+    (labelNumber !== 18 && parts.length !== 4) ||
+    (labelNumber === 18 && parts.length !== 7)
+  ) {
+    if (options?.debug) {
+      console.log(`Decoder: Unknown OOOI message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const data = parts[2].split(' ');
+  ResultFormatter.departureAirport(result, data[1]);
+  ResultFormatter.arrivalAirport(result, data[2]);
+  result.raw.day = Number(data[3]);
+  const time = DateTimeUtils.convertHHMMSSToTod(data[4]);
+  if (labelNumber === 13) {
+    ResultFormatter.out(result, time);
+  } else if (labelNumber === 14) {
+    ResultFormatter.off(result, time);
+  } else if (labelNumber === 15) {
+    ResultFormatter.on(result, time);
+  } else if (labelNumber === 16) {
+    ResultFormatter.in(result, time);
+  }
+
+  if (parts.length === 7) {
+    ResultFormatter.unknownArr(result, parts.slice(4), '/');
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].startsWith('/LOC')) {
+      const location = lines[i].substring(5).split(',');
+      let position;
+      if (location[0].startsWith('+') || location[0].startsWith('-')) {
+        position = {
+          latitude: Number(location[0]),
+          longitude: Number(location[1]),
+        };
+      } else {
+        position = {
+          latitude:
+            CoordinateUtils.getDirection(location[0][0]) *
+            CoordinateUtils.dmsToDecimalDegrees(
+              Number(location[0].substring(1, 3)),
+              Number(location[0].substring(3, 5)),
+              Number(location[0].substring(5, 7)),
+            ),
+          longitude:
+            CoordinateUtils.getDirection(location[1][0]) *
+            CoordinateUtils.dmsToDecimalDegrees(
+              Number(location[1].substring(1, 4)),
+              Number(location[1].substring(4, 6)),
+              Number(location[1].substring(6, 8)),
+            ),
+        };
+      }
+      ResultFormatter.position(result, position);
+    } else {
+      ResultFormatter.unknown(result, lines[i], '\r\n');
+    }
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = result.remaining.text ? 'partial' : 'full';
+  return result;
+}
+
+function getMsgType(labelNumber: number): string {
+  if (labelNumber === 13) return 'Out of Gate Report';
+  if (labelNumber === 14) return 'Takeoff Report';
+  if (labelNumber === 15) return 'On Ground Report';
+  if (labelNumber === 16) return 'In Gate Report';
+  if (labelNumber === 17) return 'Post Report';
+  if (labelNumber === 18) return 'Post Times Report';
+  return 'Unknown';
+}

--- a/lib/plugins/escape_hatches/Label_15.ts
+++ b/lib/plugins/escape_hatches/Label_15.ts
@@ -1,0 +1,74 @@
+// Escape-hatch port of lib/plugins/Label_15.ts
+// Called from generated plugin lib/plugins/generated/Label_15.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_15_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (message.text.startsWith('(2') && message.text.endsWith('(Z')) {
+    const between = message.text.substring(2, message.text.length - 2);
+    ResultFormatter.position(
+      result,
+      CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+        between.substring(0, 13),
+      ),
+    );
+    if (between.length === 25) {
+      // short variant
+      ResultFormatter.unknown(result, between.substring(13, 19));
+      const alt = between.substring(19, 22);
+      if (alt != '---') {
+        ResultFormatter.altitude(result, 100 * Number(alt));
+      }
+      ResultFormatter.temperature(
+        result,
+        between.substring(22).replaceAll(' ', '0'),
+      );
+    } else if (between.substring(13, 16) === 'OFF') {
+      // off variant
+      const ddmmyy = between.substring(16, 22);
+      const hhmm = between.substring(22, 26);
+      if (ddmmyy != '------') {
+        ResultFormatter.off(
+          result,
+          DateTimeUtils.convertDateTimeToEpoch(hhmm + '00', ddmmyy),
+        );
+      } else {
+        ResultFormatter.off(result, DateTimeUtils.convertHHMMSSToTod(hhmm));
+      }
+      ResultFormatter.unknown(result, between.substring(26));
+    } else {
+      ResultFormatter.unknown(result, between.substring(26));
+    }
+  } else {
+    if (options.debug) {
+      console.log(`[${plugin.name}] Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  return result;
+}
+
+export function label_15_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_15_FST.ts
+++ b/lib/plugins/escape_hatches/Label_15_FST.ts
@@ -1,0 +1,63 @@
+// Escape-hatch port of lib/plugins/Label_15_FST.ts
+// Called from generated plugin lib/plugins/generated/Label_15_FST.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_15_fst_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split(' ');
+  // FST01KMCOEGKKN505552W00118021
+  const header = parts[0];
+
+  const stringCoords = header.substring(13);
+  // Don't use decodeStringCoordinates here, because of different pos format
+
+  const firstChar = stringCoords.substring(0, 1);
+  const middleChar = stringCoords.substring(7, 8);
+  result.raw.position = {} as { latitude: number; longitude: number };
+
+  if (
+    (firstChar === 'N' || firstChar === 'S') &&
+    (middleChar === 'W' || middleChar === 'E')
+  ) {
+    const lat =
+      (Number(stringCoords.substring(1, 7)) / 10000) *
+      (firstChar === 'S' ? -1 : 1);
+    const lon =
+      (Number(stringCoords.substring(8, 15)) / 10000) *
+      (middleChar === 'W' ? -1 : 1);
+    ResultFormatter.position(result, { latitude: lat, longitude: lon });
+    ResultFormatter.altitude(result, Number(stringCoords.substring(15)) * 100);
+  } else {
+    if (options.debug) {
+      console.log(`[${plugin.name}] Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.departureAirport(result, header.substring(5, 9));
+  ResultFormatter.arrivalAirport(result, header.substring(9, 13));
+
+  ResultFormatter.unknownArr(result, parts.slice(1), ' ');
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  return result;
+}
+
+export function label_15_fst_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_16_AUTPOS.ts
+++ b/lib/plugins/escape_hatches/Label_16_AUTPOS.ts
@@ -1,0 +1,127 @@
+// Escape-hatch port of lib/plugins/Label_16_AUTPOS.ts
+// Called from generated plugin lib/plugins/generated/Label_16_AUTPOS.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_16_autpos_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  // Regex to match the AUTPOS message
+  const regex =
+    /^(\d{6})\/AUTPOS\/LLD (N|S)(\d{2})(\d{2})(\d{2}) (E|W)(\d{3})(\d{2})(\d{2})\s*\r?\n\/ALT (\d+)\/SAT ([*\-\d]{4})\r?\n\/WND ([*\d]{3})([\*\d]{3})\/TAT ([*\-\d]{4})\/TAS ([*\d]{3,4})\/CRZ ([*\d]{3,4})\r?\n\/FOB (\d{6})\r?\n\/DAT (\d{6})\/TIM (\d{6})/;
+  const match = regex.exec(message.text);
+  if (!match) {
+    result.decoded = false;
+    return result;
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+  result.formatted.description = 'Position Report';
+
+  // Extract fields
+  const [
+    ,
+    flight,
+    latHem,
+    latDeg,
+    latMin,
+    latSec,
+    lonHem,
+    lonDeg,
+    lonMin,
+    lonSec,
+    altitude,
+    sat,
+    windDir,
+    windSpd,
+    tat,
+    tas,
+    crz,
+    fob,
+    dat,
+    tim,
+  ] = match;
+
+  ResultFormatter.day(result, parseInt(flight.slice(0, 2), 10));
+  ResultFormatter.flightNumber(result, flight.slice(2));
+  let latitude = CoordinateUtils.dmsToDecimalDegrees(
+    parseInt(latDeg, 10),
+    parseInt(latMin, 10),
+    parseInt(latSec, 10),
+  );
+  if (latHem === 'S') latitude = -latitude;
+  let longitude = CoordinateUtils.dmsToDecimalDegrees(
+    parseInt(lonDeg, 10),
+    parseInt(lonMin, 10),
+    parseInt(lonSec, 10),
+  );
+  if (lonHem === 'W') longitude = -longitude;
+  ResultFormatter.position(result, {
+    latitude,
+    longitude,
+  });
+  const alt = parseInt(altitude, 10);
+  ResultFormatter.altitude(result, alt);
+
+  // Parse wind
+  if (!windSpd.includes('*') && !windDir.includes('*')) {
+    ResultFormatter.windData(result, [
+      {
+        waypoint: {
+          name: 'POSITION',
+        },
+        flightLevel: Math.round(alt / 100),
+        windDirection: parseInt(windDir, 10),
+        windSpeed: parseInt(windSpd, 10),
+      },
+    ]);
+  }
+
+  if (!tat.includes('*')) {
+    ResultFormatter.totalAirTemp(result, tat);
+  }
+  if (!tas.includes('*')) {
+    ResultFormatter.airspeed(result, parseInt(tas, 10));
+  }
+  if (!sat.includes('*')) {
+    ResultFormatter.temperature(result, sat);
+  }
+  if (!crz.includes('*')) {
+    ResultFormatter.mach(result, parseInt(crz, 10) / 1000);
+  }
+
+  if (!fob.includes('*')) {
+    ResultFormatter.currentFuel(result, parseInt(fob, 10));
+  }
+
+  if (!dat.includes('*') && !tim.includes('*')) {
+    const yy = dat.slice(0, 2);
+    const mm = dat.slice(2, 4);
+    const dd = dat.slice(4, 6);
+    const ddmmyy = `${dd}${mm}${yy}`;
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertDateTimeToEpoch(tim, ddmmyy),
+    );
+  }
+  void plugin;
+  return result;
+}
+
+export function label_16_autpos_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_16_Honeywell.ts
+++ b/lib/plugins/escape_hatches/Label_16_Honeywell.ts
@@ -1,0 +1,72 @@
+// Escape-hatch port of lib/plugins/Label_16_Honeywell.ts
+// Called from generated plugin lib/plugins/generated/Label_16_Honeywell.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_16_honeywell_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (
+    message.text.startsWith('(2') &&
+    message.text.endsWith('(Z') &&
+    message.text.length >= 29
+  ) {
+    const between = message.text.substring(2, message.text.length - 2);
+    ResultFormatter.unknown(result, between.substring(0, 4), ''); // Session ID
+    ResultFormatter.position(
+      result,
+      CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+        between.substring(4, 17),
+      ),
+    );
+    if (between.charAt(17) === '-') {
+      // Waypoint mode
+      const waypoint1 = between.substring(18, 23).trim();
+      const waypoint2 = between.substring(23, 28).trim();
+      if (waypoint2) {
+        ResultFormatter.route(result, {
+          waypoints: [{ name: waypoint1 }, { name: waypoint2 }],
+        });
+      } else {
+        ResultFormatter.route(result, {
+          waypoints: [{ name: waypoint1 }],
+        });
+      }
+    } else {
+      // Route mode
+      ResultFormatter.departureAirport(result, between.substring(17, 21));
+      ResultFormatter.arrivalAirport(result, between.substring(21, 25));
+      //ignore the rest (should just be '-')
+    }
+    ResultFormatter.unknown(result, between.substring(between.length - 2), '');
+  } else {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 16 Honeywell message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_16_honeywell_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_16_N_Space.ts
+++ b/lib/plugins/escape_hatches/Label_16_N_Space.ts
@@ -1,0 +1,98 @@
+// Escape-hatch port of lib/plugins/Label_16_N_Space.ts
+// Called from generated plugin lib/plugins/generated/Label_16_N_Space.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_16_n_space_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Style: N 44.203,W 86.546,31965,6, 290
+  const variant1Regex =
+    /^(?<lat>[NS])\s(?<lat_coord>.*),(?<long>[EW])\s*(?<long_coord>.*),(?<alt>.*),(?<unkwn1>.*),\s*(?<unkwn2>.*)$/;
+
+  // Style: N 28.177/W 96.055
+  const variant2Regex =
+    /^(?<lat>[NS])\s(?<lat_coord>.*)\/(?<long>[EW])\s*(?<long_coord>.*)$/;
+
+  let results = message.text.match(variant1Regex);
+  if (results?.groups) {
+    if (options.debug) {
+      console.log('Label 16 N : results');
+      console.log(results);
+    }
+
+    const pos = {
+      latitude:
+        Number(results.groups.lat_coord) *
+        (results.groups.lat == 'N' ? 1 : -1),
+      longitude:
+        Number(results.groups.long_coord) *
+        (results.groups.long == 'E' ? 1 : -1),
+    };
+    const altitude =
+      results.groups.alt == 'GRD' || results.groups.alt == '***'
+        ? 0
+        : Number(results.groups.alt);
+
+    ResultFormatter.position(result, pos);
+    ResultFormatter.altitude(result, altitude);
+
+    ResultFormatter.unknownArr(result, [
+      results.groups.unkwn1,
+      results.groups.unkwn2,
+    ]);
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+
+    void plugin;
+    return result;
+  }
+
+  results = message.text.match(variant2Regex);
+  if (results?.groups) {
+    if (options.debug) {
+      console.log('Label 16 N : results');
+      console.log(results);
+    }
+
+    const pos = {
+      latitude:
+        Number(results.groups.lat_coord) *
+        (results.groups.lat == 'N' ? 1 : -1),
+      longitude:
+        Number(results.groups.long_coord) *
+        (results.groups.long == 'E' ? 1 : -1),
+    };
+
+    ResultFormatter.position(result, pos);
+
+    result.decoded = true;
+    result.decoder.decodeLevel = 'full';
+    void plugin;
+    return result;
+  }
+
+  // Unknown
+  if (options.debug) {
+    console.log(`Decoder: Unknown 16 message: ${message.text}`);
+  }
+  ResultFormatter.unknown(result, message.text);
+  result.decoded = false;
+  result.decoder.decodeLevel = 'none';
+
+  void plugin;
+  return result;
+}
+
+export function label_16_n_space_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_16_POSA1.ts
+++ b/lib/plugins/escape_hatches/Label_16_POSA1.ts
@@ -1,0 +1,57 @@
+// Escape-hatch port of lib/plugins/Label_16_POSA1.ts
+// Called from generated plugin lib/plugins/generated/Label_16_POSA1.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_16_posa1_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const fields = message.text.split(',');
+  if (fields.length !== 11 || !fields[0].startsWith('POSA1')) {
+    if (options.debug) {
+      console.log(`[${plugin.name}] Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.position(
+    result,
+    CoordinateUtils.decodeStringCoordinates(fields[0].substring(5)),
+  ); // strip 'POSA1'
+  const waypoint = fields[1].trim();
+  const time = DateTimeUtils.convertHHMMSSToTod(fields[2]);
+  ResultFormatter.altitude(result, Number(fields[3]) * 100);
+  const nextWaypoint = fields[4].trim();
+  const nextTime = DateTimeUtils.convertHHMMSSToTod(fields[5]);
+  ResultFormatter.unknownArr(result, fields.slice(6), ',');
+  ResultFormatter.route(result, {
+    waypoints: [
+      { name: waypoint, time: time },
+      { name: nextWaypoint, time: nextTime },
+    ],
+  });
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  return result;
+}
+
+export function label_16_posa1_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_16_TOD.ts
+++ b/lib/plugins/escape_hatches/Label_16_TOD.ts
@@ -1,0 +1,77 @@
+// Escape-hatch port of lib/plugins/Label_16_TOD.ts
+// Called from generated plugin lib/plugins/generated/Label_16_TOD.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_16_tod_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const fields = message.text.split(',');
+  const time = DateTimeUtils.convertHHMMSSToTod(fields[0]);
+  if (fields.length !== 5 || Number.isNaN(time)) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 16 message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.timestamp(result, time);
+  if (fields[1] !== '') {
+    ResultFormatter.altitude(result, Number(fields[1]));
+  }
+  ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(fields[2]));
+  ResultFormatter.unknown(result, fields[3]);
+  const temp = fields[4].split('/');
+  const posFields = temp[0].split(' ');
+  if (posFields.length === 4) {
+    ResultFormatter.position(result, {
+      latitude:
+        CoordinateUtils.getDirection(posFields[0]) * Number(posFields[1]),
+      longitude:
+        CoordinateUtils.getDirection(posFields[2]) * Number(posFields[3]),
+    });
+  } else if (posFields.length === 2) {
+    ResultFormatter.position(result, {
+      latitude:
+        (CoordinateUtils.getDirection(posFields[0][0]) *
+          Number(posFields[0].slice(1))) /
+        100,
+      longitude:
+        (CoordinateUtils.getDirection(posFields[1][0]) *
+          Number(posFields[1].slice(1))) /
+        100,
+    });
+  } else {
+    // Redacted
+    //ResultFormatter.unknown(result, fields[4]);
+  }
+
+  if (temp.length > 1) {
+    ResultFormatter.flightNumber(result, temp[1]);
+  }
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  void plugin;
+  return result;
+}
+
+export function label_16_tod_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_1L_070.ts
+++ b/lib/plugins/escape_hatches/Label_1L_070.ts
@@ -1,0 +1,67 @@
+// Escape-hatch port of lib/plugins/Label_1L_070.ts
+// Called from generated plugin lib/plugins/generated/Label_1L_070.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_1l_070_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (!message.text.startsWith('000000070')) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const parts = message.text.substring(9).split(',');
+
+  if (parts.length !== 7) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.departureAirport(result, parts[0]);
+  ResultFormatter.arrivalAirport(result, parts[1]);
+  ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(parts[2]));
+  ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(parts[3]));
+  ResultFormatter.position(result, {
+    latitude:
+      CoordinateUtils.getDirection(parts[4][0]) *
+      Number(parts[4].substring(1)),
+    longitude:
+      CoordinateUtils.getDirection(parts[5][0]) *
+      Number(parts[5].substring(1)),
+  });
+
+  result.remaining.text = parts[6];
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_1l_070_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_1L_3Line.ts
+++ b/lib/plugins/escape_hatches/Label_1L_3Line.ts
@@ -1,0 +1,106 @@
+// Escape-hatch port of lib/plugins/Label_1L_3-line.ts
+// Called from generated plugin lib/plugins/generated/Label_1L_3Line.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_1l_3line_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const lines = message.text.split('\r\n');
+  if (lines.length !== 3) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+  const parts = message.text.replaceAll('\r\n', '/').split('/');
+  const data = new Map<string, string>();
+  data.set('', parts[0]);
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i].split(' ');
+    data.set(part[0], part.slice(1).join(' '));
+  }
+
+  const dep = data.get('DEP');
+  if (dep) {
+    ResultFormatter.departureAirport(result, dep);
+    data.delete('DEP');
+  }
+  const des = data.get('DES');
+  if (des) {
+    ResultFormatter.arrivalAirport(result, des);
+    data.delete('DES');
+  }
+  const eta = data.get('ETA');
+  if (eta) {
+    ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(eta));
+    data.delete('ETA');
+  }
+  const alt = data.get('ALT');
+  if (alt) {
+    ResultFormatter.altitude(result, Number(alt));
+    data.delete('ALT');
+  }
+  const fn = data.get('FN');
+  if (fn) {
+    ResultFormatter.flightNumber(result, fn);
+    data.delete('FN');
+  }
+  const day = data.get('DAY');
+  const utc = data.get('UTC');
+  if (day && utc) {
+    result.raw.message_timestamp =
+      Date.parse(day + ' GMT+0000') / 1000 +
+      DateTimeUtils.convertHHMMSSToTod(utc);
+    data.delete('DAY');
+    data.delete('UTC');
+  }
+
+  const lat = data.get('LAT');
+  const lon = data.get('LON');
+  if (lat && lon) {
+    ResultFormatter.position(result, {
+      latitude:
+        CoordinateUtils.getDirection(lat[0]) * Number(lat.substring(1)),
+      longitude:
+        CoordinateUtils.getDirection(lon[0]) * Number(lon.substring(1)),
+    });
+    data.delete('LAT');
+    data.delete('LON');
+  }
+
+  let remaining = '';
+  for (const [key, value] of data.entries()) {
+    if (key === '') {
+      remaining += value;
+    } else {
+      remaining += `/${key} ${value}`;
+    }
+  }
+  result.remaining.text = remaining;
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_1l_3line_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_1L_660.ts
+++ b/lib/plugins/escape_hatches/Label_1L_660.ts
@@ -1,0 +1,67 @@
+// Escape-hatch port of lib/plugins/Label_1L_660.ts
+// Called from generated plugin lib/plugins/generated/Label_1L_660.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_1l_660_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (!message.text.startsWith('000000660')) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const parts = message.text.substring(9).split(',');
+
+  if (parts.length !== 5) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+    parts[0],
+  );
+  if (position) {
+    ResultFormatter.position(result, position);
+  }
+  const hhmmss = parts[1].substring(0, 6);
+  ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(hhmmss));
+  const fl = parts[1].substring(6, 9);
+  ResultFormatter.altitude(result, Number(fl) * 100);
+  const next = parts[1].substring(9);
+  ResultFormatter.route(result, { waypoints: [{ name: next.trim() }] });
+
+  result.remaining.text = parts.slice(2).join(',');
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_1l_660_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_1L_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_1L_Slash.ts
@@ -1,0 +1,81 @@
+// Escape-hatch port of lib/plugins/Label_1L_Slash.ts
+// Called from generated plugin lib/plugins/generated/Label_1L_Slash.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_1l_slash_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split('/');
+
+  if (parts.length !== 7) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 1L message: ${message.text}`);
+    }
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const data = new Map<string, string>();
+  data.set('LAT', parts[0].replaceAll(' ', ''));
+  data.set('LON', parts[1].replaceAll(' ', ''));
+  for (let i = 2; i < parts.length; i++) {
+    const part = parts[i].split(' ');
+    data.set(part[0], part.slice(1).join(' '));
+  }
+
+  const position = {
+    latitude: Number(data.get('LAT')),
+    longitude: Number(data.get('LON')),
+  };
+  data.delete('LAT');
+  data.delete('LON');
+
+  ResultFormatter.position(result, position);
+  const utc = data.get('UTC');
+  if (utc) {
+    ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(utc));
+    data.delete('UTC');
+  }
+  const alt = data.get('ALT');
+  if (alt) {
+    ResultFormatter.altitude(result, Number(alt));
+    data.delete('ALT');
+  }
+  const fob = data.get('FOB');
+  if (fob) {
+    ResultFormatter.currentFuel(result, Number(fob));
+    data.delete('FOB');
+  }
+  const eta = data.get('ETA');
+  if (eta) {
+    ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(eta));
+    data.delete('ETA');
+  }
+
+  let remaining = '';
+  for (const [key, value] of data.entries()) {
+    remaining += `/${key} ${value}`;
+  }
+  result.remaining.text = remaining;
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  void plugin;
+  return result;
+}
+
+export function label_1l_slash_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_1M_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_1M_Slash.ts
@@ -1,0 +1,59 @@
+// Escape-hatch port of lib/plugins/Label_1M_Slash.ts
+// Called from generated plugin lib/plugins/generated/Label_1M_Slash.ts.
+
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_1m_slash_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Style: /BA0843/ETA01/230822/LDSP/EGLL/EGSS/2JK0(NEW LINE)1940/EGLL27L/10
+  const results = message.text.split(/\n|\//).slice(1); // Split by / and new line
+
+  if (results) {
+    if (options.debug) {
+      console.log('Label 1M ETA: results');
+      console.log(results);
+    }
+
+    result.raw.flight_number = results[0];
+    // results[1]: ETA01 (???)
+    // results[2]: 230822 - UTC date of eta
+    ResultFormatter.departureAirport(result, results[3]);
+    ResultFormatter.arrivalAirport(result, results[4]);
+    ResultFormatter.alternateAirport(result, results[5]);
+    // results[6]: 2JK0 (???)
+    // results[7] 1940 - UTC eta
+    ResultFormatter.arrivalRunway(result, results[8].replace(results[4], '')); // results[8] EGLL27L
+    // results[9]: 10(space) (???)
+
+    const yymmdd = results[2];
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertDateTimeToEpoch(
+        results[7] + '00',
+        yymmdd.substring(4, 6) +
+          yymmdd.substring(2, 4) +
+          yymmdd.substring(0, 2),
+      ),
+    );
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  void plugin;
+  return result;
+}
+
+export function label_1m_slash_format(_result: DecodeResult): void {
+  // No-op.
+}

--- a/lib/plugins/escape_hatches/Label_20_CFB01.ts
+++ b/lib/plugins/escape_hatches/Label_20_CFB01.ts
@@ -1,0 +1,72 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_20_CFB01 (#CFB.01 — Crew Flight Bag).
+ *
+ * Ported from lib/plugins/Label_20_CFB.01.ts. Behavior:
+ *   - Named-group regex over IN02,coords,dep,arr,date,time,fuel_in_tons.
+ *   - Position via CoordinateUtils.decodeStringCoordinates.
+ *   - current_time computed via Date.parse with new Date().getFullYear() —
+ *     preserves byte-for-byte behavior (varies with the year the test runs).
+ *   - fuel_in_tons only emitted when not "***"/"****".
+ *   - Always reports decoded=true, decodeLevel='full' (matches TS source even
+ *     when regex misses).
+ */
+export function label_20_cfb01_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Style: IN02,N38338W121179,KMHR,KPDX,0806,2355,005.1
+  const regex =
+    /^IN02,(?<unsplit_coords>.*),(?<departure_icao>.*),(?<arrival_icao>.*),(?<current_date>.*),(?<current_time>.*),(?<fuel_in_tons>.*)$/;
+  const results = message.text.match(regex);
+  if (results?.groups) {
+    if (options.debug) {
+      console.log('Label 44 ETA Report: groups');
+      console.log(results.groups);
+    }
+
+    ResultFormatter.position(
+      result,
+      CoordinateUtils.decodeStringCoordinates(results.groups.unsplit_coords),
+    );
+    ResultFormatter.departureAirport(result, results.groups.departure_icao);
+    ResultFormatter.arrivalAirport(result, results.groups.arrival_icao);
+
+    result.raw.current_time = Date.parse(
+      new Date().getFullYear() +
+        '-' +
+        results.groups.current_date.substr(0, 2) +
+        '-' +
+        results.groups.current_date.substr(2, 2) +
+        'T' +
+        results.groups.current_time.substr(0, 2) +
+        ':' +
+        results.groups.current_time.substr(2, 2) +
+        ':00Z',
+    );
+
+    if (
+      results.groups.fuel_in_tons != '***' &&
+      results.groups.fuel_in_tons != '****'
+    ) {
+      result.raw.fuel_in_tons = Number(results.groups.fuel_in_tons);
+    }
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_20_POS.ts
+++ b/lib/plugins/escape_hatches/Label_20_POS.ts
@@ -1,0 +1,56 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_20_POS (POS preamble — Position Report).
+ *
+ * Ported from lib/plugins/Label_20_POS.ts. Behavior:
+ *   - Records the 3-char preamble to raw.preamble.
+ *   - Splits remainder on ',' and branches on 11-field vs 5-field variants;
+ *     both extract position from field[0] via CoordinateUtils.
+ *   - Unknown field counts produce decoded=false / decodeLevel='none'.
+ */
+export function label_20_pos_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  result.raw.preamble = message.text.substring(0, 3);
+
+  const content = message.text.substring(3);
+  const fields = content.split(',');
+
+  if (fields.length == 11) {
+    plugin.debug(options, 'Variation 1 detected');
+    const rawCoords = fields[0];
+    ResultFormatter.position(
+      result,
+      CoordinateUtils.decodeStringCoordinates(rawCoords),
+    );
+
+    plugin.setDecodeLevel(result, true, 'full');
+  } else if (fields.length == 5) {
+    plugin.debug(options, 'Variation 2 detected');
+    const position = CoordinateUtils.decodeStringCoordinates(fields[0]);
+    if (position) {
+      ResultFormatter.position(result, position);
+    }
+    plugin.setDecodeLevel(result, true, 'full');
+  } else {
+    plugin.debug(
+      options,
+      `Unknown variation. Field count: ${fields.length}, content: ${content}`,
+    );
+    plugin.setDecodeLevel(result, false);
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_21_POS.ts
+++ b/lib/plugins/escape_hatches/Label_21_POS.ts
@@ -1,0 +1,81 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_21_POS (POS preamble — Position Report).
+ *
+ * Ported from lib/plugins/Label_21_POS.ts. Behavior:
+ *   - Records the 3-char preamble to raw.preamble.
+ *   - Splits remainder on ','; expects exactly 9 fields.
+ *   - processPosition decodes a 16-char "N 39.841W 75.790" layout (NSEW at
+ *     offsets 0 and 8) with the original's quirky `&&` guard predicate.
+ *   - Emits timestamp (HHMMSS), altitude, whitespace-stripped temperature,
+ *     ETA (HHMMSS), arrival airport, and an unknownArr of [f1, f4, f5].
+ */
+export function label_21_pos_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  result.raw.preamble = message.text.substring(0, 3);
+
+  const content = message.text.substring(3);
+  const fields = content.split(',');
+
+  if (fields.length == 9) {
+    // POSN 37.550W 76.436,  98,110800,23961,25820,  65,-23,114212,KRDU
+    processPosition(result, fields[0].trim());
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[2]),
+    );
+    ResultFormatter.altitude(result, Number(fields[3]));
+    ResultFormatter.temperature(result, fields[6].replace(/ /g, ''));
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[7]),
+    );
+    ResultFormatter.arrivalAirport(result, fields[8]);
+
+    ResultFormatter.unknownArr(result, [fields[1], fields[4], fields[5]]);
+
+    plugin.setDecodeLevel(result, true, 'partial');
+  } else {
+    plugin.debug(
+      options,
+      `Unknown variation. Field count: ${fields.length}, content: ${content}`,
+    );
+    plugin.setDecodeLevel(result, false);
+  }
+  return result;
+}
+
+function processPosition(decodeResult: DecodeResult, value: string) {
+  // N 39.841W 75.790
+  if (
+    value.length !== 16 &&
+    value[0] !== 'N' &&
+    value[0] !== 'S' &&
+    value[8] !== 'W' &&
+    value[8] !== 'E'
+  ) {
+    return;
+  }
+  const latDir = value[0] === 'N' ? 1 : -1;
+  const lonDir = value[8] === 'E' ? 1 : -1;
+  const position = {
+    latitude: latDir * Number(value.substring(1, 7)),
+    longitude: lonDir * Number(value.substring(9, 15)),
+  };
+
+  ResultFormatter.position(decodeResult, position);
+}

--- a/lib/plugins/escape_hatches/Label_22_OFF.ts
+++ b/lib/plugins/escape_hatches/Label_22_OFF.ts
@@ -1,0 +1,110 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_22_OFF (OFF preamble — Takeoff Report).
+ *
+ * Ported from lib/plugins/Label_22_OFF.ts. Behavior:
+ *   - Three variants dispatched on "OFF01" / "OFF02\r\n" / "OFF02" prefixes.
+ *   - Variant 1 (OFF01): slash-split + fixed-substring layout for flight
+ *     number, departure/arrival days, timestamp, dep/arr airports, OFF time.
+ *   - Variant 2 (OFF02): slash-split + fixed-substring layout including a
+ *     decimal-minutes position and an ETA field.
+ *   - Variant 3 (OFF02\r\n): comma-split into [dep, arr, off-time, unknown].
+ *   - All variants set decodeLevel='partial' on success, 'none' otherwise.
+ */
+export function label_22_off_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (message.text.startsWith('OFF01')) {
+    // variant 1
+    const fields = message.text.substring(5).split('/');
+
+    if (fields.length != 2) {
+      plugin.setDecodeLevel(result, false);
+      return result;
+    }
+
+    ResultFormatter.flightNumber(result, fields[0]);
+    ResultFormatter.departureDay(result, Number(fields[1].substring(0, 2))); // departure day
+    ResultFormatter.arrivalDay(result, Number(fields[1].substring(2, 4))); // arrival day
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[1].substring(4, 8)),
+    );
+    ResultFormatter.departureAirport(result, fields[1].substring(8, 12));
+    ResultFormatter.arrivalAirport(result, fields[1].substring(12, 16));
+    ResultFormatter.off(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[1].substring(16, 22)),
+    );
+    ResultFormatter.unknown(result, fields[1].substring(22));
+
+    plugin.setDecodeLevel(result, true, 'partial');
+  } else if (message.text.startsWith('OFF02\r\n')) {
+    // varaint 3
+    const fields = message.text.substring(7).split(',');
+    if (fields.length != 4) {
+      plugin.setDecodeLevel(result, false);
+      return result;
+    }
+
+    ResultFormatter.departureAirport(result, fields[0]);
+    ResultFormatter.arrivalAirport(result, fields[1]);
+    ResultFormatter.off(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[2]),
+    );
+    ResultFormatter.unknown(result, fields[3]);
+
+    plugin.setDecodeLevel(result, true, 'partial');
+  } else if (message.text.startsWith('OFF02')) {
+    // varaint 2
+    const fields = message.text.substring(5).split('/');
+    if (fields.length != 2) {
+      plugin.setDecodeLevel(result, false);
+      return result;
+    }
+
+    ResultFormatter.flightNumber(result, fields[0]);
+    const position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+      fields[1].substring(0, 14),
+    );
+    if (position) {
+      ResultFormatter.position(result, position);
+    }
+    ResultFormatter.day(result, Number(fields[1].substring(14, 16)));
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[1].substring(16, 20)),
+    );
+    ResultFormatter.departureAirport(result, fields[1].substring(20, 24));
+    ResultFormatter.arrivalAirport(result, fields[1].substring(24, 28));
+    ResultFormatter.off(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[1].substring(28, 32)),
+    );
+    ResultFormatter.unknown(result, fields[1].substring(32, 36));
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[1].substring(36, 40)),
+    );
+    plugin.setDecodeLevel(result, true, 'partial');
+  } else {
+    plugin.debug(options, 'Unknown variation.');
+    plugin.setDecodeLevel(result, false);
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_22_POS.ts
+++ b/lib/plugins/escape_hatches/Label_22_POS.ts
@@ -1,0 +1,59 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_22_POS (N/S preambles — Position Report).
+ *
+ * Ported from lib/plugins/Label_22_POS.ts. Behavior:
+ *   - Splits message.text on ',' and requires exactly 11 fields.
+ *   - Position derives from field[0]: 7-char latitude at [1..8], longitude at
+ *     [9..end], NSEW signs at offsets 0 and 8, divisor 10000.
+ *   - Emits HHMMSS timestamp from field[2], altitude from field[3], then an
+ *     unknownArr of [field[1], ...fields.slice(4)].
+ */
+export function label_22_pos_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const fields = message.text.split(',');
+
+  if (fields.length !== 11) {
+    plugin.debug(
+      options,
+      `Unknown variation. Field count: ${fields.length}, content: ${fields.join(',')}`,
+    );
+    plugin.setDecodeLevel(result, false);
+    return result;
+  }
+
+  const latStr = fields[0].substring(1, 8);
+  const lonStr = fields[0].substring(9);
+  const lat = Number(latStr) / 10000;
+  const lon = Number(lonStr) / 10000;
+  ResultFormatter.position(result, {
+    latitude: CoordinateUtils.getDirection(fields[0][0]) * lat,
+    longitude: CoordinateUtils.getDirection(fields[0][8]) * lon,
+  });
+
+  ResultFormatter.timestamp(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(fields[2]),
+  );
+  ResultFormatter.altitude(result, Number(fields[3]));
+
+  ResultFormatter.unknownArr(result, [fields[1], ...fields.slice(4)]);
+
+  plugin.setDecodeLevel(result, true, 'partial');
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_24_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_24_Slash.ts
@@ -1,0 +1,71 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_24_Slash ("/" preamble — Position Report).
+ *
+ * Ported from lib/plugins/Label_24_Slash.ts. Behavior:
+ *   - Splits on '/'; requires length 10 with both first and last empty
+ *     (message begins and ends with '/').
+ *   - Rearranges field[1] DDMMYY -> YYDDMM, appends '00' to field[2] HHMM,
+ *     and computes raw.message_timestamp via DateTimeUtils.convertDateTimeToEpoch.
+ *   - Char-prefix sign decoding (N/E => +1, S/W => -1) for coords.
+ *   - Emits flight number, altitude, position, ETA, and one unknown field.
+ *   - Unknown variations log via console.log (preserving original behavior).
+ */
+export function label_24_slash_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const fields = message.text.split('/');
+
+  if (fields.length == 10 && fields[0] == '' && fields[9] == '') {
+    // begin and ends with `/`
+    const ddmmyy =
+      fields[1].substring(2, 4) +
+      fields[1].substring(4, 6) +
+      fields[1].substring(0, 2); // YYDDMM
+    const hhmmss = fields[2] + '00';
+    result.raw.message_timestamp = DateTimeUtils.convertDateTimeToEpoch(
+      hhmmss,
+      ddmmyy,
+    );
+    ResultFormatter.flightNumber(result, fields[3]);
+    ResultFormatter.altitude(result, Number(fields[4]));
+    const lat = fields[5];
+    const lon = fields[6];
+    const position = {
+      latitude: (lat[0] === 'N' ? 1 : -1) * Number(lat.substring(1)),
+      longitude: (lon[0] === 'E' ? 1 : -1) * Number(lon.substring(1)),
+    };
+    ResultFormatter.position(result, position);
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[8]),
+    );
+    ResultFormatter.unknown(result, fields[7]);
+
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    // Unknown!
+    if (options.debug) {
+      console.log(
+        `DEBUG: ${plugin.name}: Unknown variation. Field count: ${fields.length}. Message: ${message.text}`,
+      );
+    }
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_2P_FM3.ts
+++ b/lib/plugins/escape_hatches/Label_2P_FM3.ts
@@ -1,0 +1,99 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_2P_FM3 (Flight Report — FM3 variant).
+ *
+ * Ported from lib/plugins/Label_2P_FM3.ts. Behavior:
+ *   - Splits on ',' and requires 7 fields.
+ *   - header = parts[0].split('FM3 '); if header[0] is non-empty the first
+ *     4 chars are emitted as unknown and the remainder as flight number.
+ *   - timestamp and eta come via DateTimeUtils.convertHHMMSSToTod.
+ *   - Coords (parts[2], parts[3]) are whitespace-stripped; if lat starts
+ *     with N/S the char prefix sign-encodes the value, otherwise the value
+ *     is treated as a bare decimal.
+ *   - Altitude from parts[4]; parts[5] and parts[6] emitted as unknown.
+ *   - Unknown variation: ResultFormatter.unknown + decoded=false / 'none'.
+ */
+export function label_2p_fm3_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split(',');
+
+  if (parts.length === 7) {
+    const header = parts[0].split('FM3 ');
+    if (header.length == 0) {
+      // can't use preambles, as there can be info before `FM4`
+      // so let's check if we want to decode it here
+      ResultFormatter.unknown(result, message.text);
+      result.decoded = false;
+      result.decoder.decodeLevel = 'none';
+      return result;
+    }
+
+    if (header[0].length > 0) {
+      ResultFormatter.unknown(result, header[0].substring(0, 4));
+      ResultFormatter.flightNumber(result, header[0].substring(4));
+    }
+
+    if (header[1].length === 4) {
+      ResultFormatter.timestamp(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(header[1]),
+      );
+    } else {
+      ResultFormatter.timestamp(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(header[1]),
+      );
+    }
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(parts[1]),
+    );
+    const lat = parts[2].replaceAll(' ', '');
+    const lon = parts[3].replaceAll(' ', '');
+    if (lat[0] === 'N' || lat[0] === 'S') {
+      ResultFormatter.position(result, {
+        latitude:
+          CoordinateUtils.getDirection(lat[0]) * Number(lat.substring(1)),
+        longitude:
+          CoordinateUtils.getDirection(lon[0]) * Number(lon.substring(1)),
+      });
+    } else {
+      ResultFormatter.position(result, {
+        latitude: Number(lat),
+        longitude: Number(lon),
+      });
+    }
+    ResultFormatter.altitude(result, Number(parts[4]));
+    // TODO: decode further
+    ResultFormatter.unknown(result, parts[5]);
+    ResultFormatter.unknown(result, parts[6]);
+
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    // Unknown
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_2P_FM4.ts
+++ b/lib/plugins/escape_hatches/Label_2P_FM4.ts
@@ -1,0 +1,81 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_2P_FM4 (Flight Report — FM4 variant).
+ *
+ * Ported from lib/plugins/Label_2P_FM4.ts. Behavior:
+ *   - Splits on ',' and requires 10 fields.
+ *   - header = parts[0].split('FM4'); if header[0] is non-empty the first
+ *     4 chars are emitted as unknown and the remainder as flight number.
+ *   - Departure airport from header[1], arrival from parts[1].
+ *   - Day = parts[2].substring(0,2), timestamp = parts[2].substring(2).
+ *   - ETA from parts[3]; coords are bare decimals from parts[4]/parts[5]
+ *     (whitespace-stripped). Altitude parts[6], heading parts[7].
+ *   - parts[8] and parts[9] emitted as unknown.
+ */
+export function label_2p_fm4_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split(',');
+
+  if (parts.length === 10) {
+    const header = parts[0].split('FM4');
+    if (header.length == 0) {
+      // can't use preambles, as there can be info before `FM4`
+      // so let's check if we want to decode it here
+      ResultFormatter.unknown(result, message.text);
+      result.decoded = false;
+      result.decoder.decodeLevel = 'none';
+      return result;
+    }
+    if (header[0].length > 0) {
+      ResultFormatter.unknown(result, header[0].substring(0, 4));
+      ResultFormatter.flightNumber(result, header[0].substring(4));
+    }
+    ResultFormatter.departureAirport(result, header[1]);
+    ResultFormatter.arrivalAirport(result, parts[1]);
+    ResultFormatter.day(result, Number(parts[2].substring(0, 2)));
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(parts[2].substring(2)),
+    );
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(parts[3]),
+    );
+    ResultFormatter.position(result, {
+      latitude: Number(parts[4].replaceAll(' ', '')),
+      longitude: Number(parts[5].replaceAll(' ', '')),
+    });
+    ResultFormatter.altitude(result, Number(parts[6]));
+    ResultFormatter.heading(result, Number(parts[7]));
+    // TODO: decode further
+    ResultFormatter.unknown(result, parts[8]);
+    ResultFormatter.unknown(result, parts[9]);
+
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    // Unknown
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_2P_FM5.ts
+++ b/lib/plugins/escape_hatches/Label_2P_FM5.ts
@@ -1,0 +1,78 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_2P_FM5 (Flight Report — FM5 variant).
+ *
+ * Ported from lib/plugins/Label_2P_FM5.ts. Behavior:
+ *   - Splits on ',' and requires 12 fields.
+ *   - header = parts[0].split('FM5 '); departure airport = header[1].
+ *   - Arrival airport = parts[1]; timestamp = parts[2], eta = parts[3]
+ *     (both via DateTimeUtils.convertHHMMSSToTod).
+ *   - Coords from parts[4]/parts[5] (whitespace-stripped, bare decimals).
+ *   - Altitude parts[6]; parts[7..9] emitted as unknown.
+ *   - Trimmed flight number = parts[10]; parts[11] emitted as unknown.
+ */
+export function label_2p_fm5_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split(',');
+
+  if (parts.length === 12) {
+    const header = parts[0].split('FM5 ');
+    if (header.length == 0) {
+      // can't use preambles, as there can be info before `FM4`
+      // so let's check if we want to decode it here
+      ResultFormatter.unknown(result, message.text);
+      result.decoded = false;
+      result.decoder.decodeLevel = 'none';
+      return result;
+    }
+
+    ResultFormatter.departureAirport(result, header[1]);
+    ResultFormatter.arrivalAirport(result, parts[1]);
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(parts[2]),
+    );
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(parts[3]),
+    );
+    ResultFormatter.position(result, {
+      latitude: Number(parts[4].replaceAll(' ', '')),
+      longitude: Number(parts[5].replaceAll(' ', '')),
+    });
+    ResultFormatter.altitude(result, Number(parts[6]));
+    // TODO: decode further
+    ResultFormatter.unknown(result, parts[7]);
+    ResultFormatter.unknown(result, parts[8]);
+    ResultFormatter.unknown(result, parts[9]);
+    ResultFormatter.flightNumber(result, parts[10].trim());
+    ResultFormatter.unknown(result, parts[11]);
+
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    // Unknown
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_30_Slash_EA.ts
+++ b/lib/plugins/escape_hatches/Label_30_Slash_EA.ts
@@ -1,0 +1,59 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_30_Slash_EA (/EA preamble — ETA Report).
+ *
+ * Ported from lib/plugins/Label_30_Slash_EA.ts. Behavior:
+ *   - Splits on /\n|\// and slices off the first element.
+ *   - ETA = HHMMSS from results[0].substr(2, 4).
+ *   - If results[1] starts with "DS", arrival airport = results[1][2..6]
+ *     and results[2] is emitted (prefixed with '/') as unknown.
+ *   - Otherwise results[1] and results[2] are joined with '/' and emitted
+ *     as a single unknown (also prefixed with '/').
+ *   - Always reports decoded=true, decodeLevel='partial'.
+ */
+export function label_30_slash_ea_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Style: /EA1830/DSKSFO/SK24
+  const results = message.text.split(/\n|\//).slice(1); // Split by / and new line
+
+  if (results) {
+    if (options.debug) {
+      console.log('Label 30 EA: results');
+      console.log(results);
+    }
+  }
+
+  ResultFormatter.eta(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(results[0].substr(2, 4)),
+  );
+
+  if (results[1].substring(0, 2) === 'DS') {
+    ResultFormatter.arrivalAirport(result, results[1].substring(2, 6));
+    ResultFormatter.unknown(result, '/'.concat(results[2]));
+  } else {
+    ResultFormatter.unknown(
+      result,
+      '/'.concat(results[1], '/', results[2]),
+    );
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_44_POS.ts
+++ b/lib/plugins/escape_hatches/Label_44_POS.ts
@@ -1,0 +1,20 @@
+/**
+ * Field-level hatches for Label_44_POS:
+ *   - parse_flight_level_or_ground(value): "GRD" / "***" → 0, else Number(value)
+ *   - flight_level_to_altitude_feet(value): value * 100
+ *
+ * Both mirror the inline logic in lib/plugins/Label_44_POS.ts:
+ *   const flight_level = (group == 'GRD' || group == '***') ? 0 : Number(group);
+ *   ResultFormatter.altitude(decodeResult, flight_level * 100);
+ */
+
+export function parse_flight_level_or_ground(value: unknown, _args: Record<string, unknown>): number {
+  const s = typeof value === 'string' ? value : String(value ?? '');
+  if (s === 'GRD' || s === '***') return 0;
+  return Number(s);
+}
+
+export function flight_level_to_altitude_feet(value: unknown, _args: Record<string, unknown>): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return n * 100;
+}

--- a/lib/plugins/escape_hatches/Label_44_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_44_Slash.ts
@@ -1,0 +1,90 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  FlightPlanUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_44_Slash (" /FB" preamble — Flight Briefing).
+ *
+ * Ported from lib/plugins/Label_44_Slash.ts. Behavior:
+ *   - Splits on '/'; requires exactly 4 outer fields.
+ *   - First two outer fields (space + briefing id) emitted as unknownArr.
+ *   - fields[3] is split on ',' (>= 6 inner fields required).
+ *   - Position char-prefix decoded (S => -1 lat, W => -1 lon).
+ *   - Flight number, status (unknown), arrival airport, ETA from inner [2..5].
+ *   - If inner length is exactly 18, additionally emits remainingFuel,
+ *     arrivalRunway, and an arrival procedure via FlightPlanUtils.addProcedure,
+ *     interleaved with unknownArr emissions.
+ *   - On any failure: ResultFormatter.unknown + decoded=false / 'none'.
+ */
+export function label_44_slash_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const fields = message.text.split('/');
+  if (fields.length !== 4) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 44 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+  ResultFormatter.unknownArr(result, fields.slice(0, 2), '/'); // 0 is a space
+  // 1 is the briefing id
+  // 2 is arrival airport, but repeated later
+  const data = fields[3].split(',');
+  if (data.length >= 6) {
+    if (options.debug) {
+      console.log('Label 44 Slash: groups');
+      console.log(data);
+    }
+
+    ResultFormatter.position(result, {
+      latitude:
+        (data[0].charAt(0) === 'S' ? -1 : 1) *
+        parseFloat(data[0].slice(1).trim()),
+      longitude:
+        (data[1].charAt(0) === 'W' ? -1 : 1) *
+        parseFloat(data[1].slice(1).trim()),
+    });
+    ResultFormatter.flightNumber(result, data[2]);
+    ResultFormatter.unknown(result, data[3]); // Status - need more info to decode
+    ResultFormatter.arrivalAirport(result, data[4]);
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(data[5]),
+    );
+    if (data.length === 18) {
+      ResultFormatter.unknownArr(result, data.slice(6, 8), ','); // 6 is repeated arrival airport
+      ResultFormatter.remainingFuel(result, parseFloat(data[8]));
+      ResultFormatter.unknownArr(result, data.slice(9, 11), ',');
+      ResultFormatter.arrivalRunway(result, data[11]);
+      FlightPlanUtils.addProcedure(result, data[12], 'arrival');
+      ResultFormatter.unknownArr(result, data.slice(13, 18), ',');
+    }
+  } else {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 44 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4A.ts
+++ b/lib/plugins/escape_hatches/Label_4A.ts
@@ -1,0 +1,67 @@
+import type { DecodeResult } from '@airframes/ads-runtime-ts';
+
+/**
+ * Field-level + formatter hatches for Label_4A (top-level Latest New Format).
+ *
+ * NOTE: Unlike most plugins in this batch, the Label_4A spec at
+ * vendor/airframes-decoder/spec/labels/4A.yaml does NOT use a whole-plugin
+ * parse-custom hatch. It uses declarative `parse` + `variants` with two
+ * field-level custom hatches and a formatter-level custom hatch:
+ *
+ *   - label_4a_variant_2_decode (field-level)   → (value, args) => unknown
+ *   - label_4a_variant_3_position (field-level) → (value, args) => unknown
+ *   - label_4a_format (formatter-level)         → (result) => void
+ *
+ * The generated plugin (lib/plugins/generated/Label_4A.ts) stores the
+ * helpers' return values into result.raw.* (timestamp, eta, altitude,
+ * tail, callsign, departure_icao, arrival_icao, variant_2_result,
+ * position) but does NOT emit any ResultFormatter.* items inline.
+ * That means label_4a_format(result) must be the sole producer of
+ * formatted.items for every variant — a non-trivial design decision that
+ * needs clarification against the hand-written behavior (see
+ * lib/plugins/Label_4A.ts and lib/plugins/Label_4A.test.ts for expected
+ * items per variant).
+ *
+ * Stubbing per the task brief ("Bias toward correctness. Stub with throw
+ * for anything too complex to do cleanly in this pass.") so we don't ship
+ * a guess that drifts from the hand-written plugin's output. The
+ * hand-written Label_4A continues to be registered in MessageDecoder
+ * until the format/decode hatch contract is finalized.
+ */
+
+export function label_4a_variant_2_decode(
+  _value: unknown,
+  _args: Record<string, unknown>,
+): unknown {
+  throw new Error(
+    'TODO: port from lib/plugins/Label_4A.ts (variant 2 branch). Design ' +
+      'question: should the field-level hatch return position+altitude+' +
+      'route+temperature+unknownArr as a structured object that ' +
+      'label_4a_format consumes, or should it call ResultFormatter ' +
+      'directly via a captured result reference? The generated plugin ' +
+      'only stores the return into result.raw.variant_2_result.',
+  );
+}
+
+export function label_4a_variant_3_position(
+  _value: unknown,
+  _args: Record<string, unknown>,
+): unknown {
+  throw new Error(
+    'TODO: port from lib/plugins/Label_4A.ts (variant 3 branch). The ' +
+      'hand-written plugin builds the position from ' +
+      '`(fields[4] + fields[5]).replace(/[ \\.]/g, "")` via ' +
+      'CoordinateUtils.decodeStringCoordinates. The generated plugin ' +
+      'stores the return into result.raw.position.',
+  );
+}
+
+export function label_4a_format(_result: DecodeResult): void {
+  throw new Error(
+    'TODO: port from lib/plugins/Label_4A.ts. label_4a_format must emit ' +
+      'all formatted.items for every variant because the generated ' +
+      'plugin only writes to result.raw.* (no inline ResultFormatter ' +
+      'calls). See lib/plugins/Label_4A.test.ts for the expected items ' +
+      'per variant.',
+  );
+}

--- a/lib/plugins/escape_hatches/Label_4A.ts
+++ b/lib/plugins/escape_hatches/Label_4A.ts
@@ -1,67 +1,86 @@
-import type { DecodeResult } from '@airframes/ads-runtime-ts';
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+  Waypoint,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
 
 /**
- * Field-level + formatter hatches for Label_4A (top-level Latest New Format).
+ * Whole-plugin parse hatch for Label_4A. Mirrors lib/plugins/Label_4A.ts:
+ * three variants selected by field count + first-char inspection, each
+ * doing inline ResultFormatter.* calls.
  *
- * NOTE: Unlike most plugins in this batch, the Label_4A spec at
- * vendor/airframes-decoder/spec/labels/4A.yaml does NOT use a whole-plugin
- * parse-custom hatch. It uses declarative `parse` + `variants` with two
- * field-level custom hatches and a formatter-level custom hatch:
- *
- *   - label_4a_variant_2_decode (field-level)   → (value, args) => unknown
- *   - label_4a_variant_3_position (field-level) → (value, args) => unknown
- *   - label_4a_format (formatter-level)         → (result) => void
- *
- * The generated plugin (lib/plugins/generated/Label_4A.ts) stores the
- * helpers' return values into result.raw.* (timestamp, eta, altitude,
- * tail, callsign, departure_icao, arrival_icao, variant_2_result,
- * position) but does NOT emit any ResultFormatter.* items inline.
- * That means label_4a_format(result) must be the sole producer of
- * formatted.items for every variant — a non-trivial design decision that
- * needs clarification against the hand-written behavior (see
- * lib/plugins/Label_4A.ts and lib/plugins/Label_4A.test.ts for expected
- * items per variant).
- *
- * Stubbing per the task brief ("Bias toward correctness. Stub with throw
- * for anything too complex to do cleanly in this pass.") so we don't ship
- * a guess that drifts from the hand-written plugin's output. The
- * hand-written Label_4A continues to be registered in MessageDecoder
- * until the format/decode hatch contract is finalized.
+ * The spec at vendor/airframes-decoder/spec/labels/4A.yaml was switched
+ * from a declarative variants+field-customs shape to a whole-plugin
+ * parse-custom hatch because the field-level customs lacked a clean
+ * contract for who owns the formatted.items list. The whole-plugin shape
+ * is what other complex plugins (CBand, ARINC_702, MIAM, …) use.
  */
+export function label_4a_dispatch(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const fields = message.text.split(',');
 
-export function label_4a_variant_2_decode(
-  _value: unknown,
-  _args: Record<string, unknown>,
-): unknown {
-  throw new Error(
-    'TODO: port from lib/plugins/Label_4A.ts (variant 2 branch). Design ' +
-      'question: should the field-level hatch return position+altitude+' +
-      'route+temperature+unknownArr as a structured object that ' +
-      'label_4a_format consumes, or should it call ResultFormatter ' +
-      'directly via a captured result reference? The generated plugin ' +
-      'only stores the return into result.raw.variant_2_result.',
-  );
+  if (fields.length === 11) {
+    // Variant 1
+    ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(fields[0]));
+    ResultFormatter.tail(result, fields[2].replace('.', ''));
+    if (fields[3]) ResultFormatter.callsign(result, fields[3]);
+    ResultFormatter.departureAirport(result, fields[4]);
+    ResultFormatter.arrivalAirport(result, fields[5]);
+    ResultFormatter.unknownArr(result, fields.slice(8));
+  } else if (fields.length === 6) {
+    if (fields[0].match(/^[NS]/)) {
+      // Variant 2: position + waypoints
+      ResultFormatter.position(
+        result,
+        CoordinateUtils.decodeStringCoordinates(fields[0].substring(0, 13)),
+      );
+      const wp1: Waypoint = {
+        name: fields[0].substring(13).trim(),
+        time: DateTimeUtils.convertHHMMSSToTod(fields[1].substring(0, 6)),
+      };
+      ResultFormatter.altitude(result, Number(fields[1].substring(6, 9)) * 100);
+      const wp2: Waypoint = {
+        name: fields[1].substring(9).trim(),
+        time: DateTimeUtils.convertHHMMSSToTod(fields[2]),
+      };
+      ResultFormatter.route(result, { waypoints: [wp1, wp2] });
+      ResultFormatter.temperature(result, fields[3]);
+      ResultFormatter.unknownArr(result, fields.slice(4));
+    } else {
+      // Variant 3: timestamp + eta + altitude + position
+      ResultFormatter.timestamp(result, DateTimeUtils.convertHHMMSSToTod(fields[0]));
+      ResultFormatter.eta(result, DateTimeUtils.convertHHMMSSToTod(fields[1]));
+      ResultFormatter.unknown(result, fields[2]);
+      ResultFormatter.altitude(result, Number(fields[3]));
+      ResultFormatter.position(
+        result,
+        CoordinateUtils.decodeStringCoordinates(
+          (fields[4] + fields[5]).replace(/[ \.]/g, ''),
+        ),
+      );
+    }
+  } else {
+    result.decoded = false;
+    ResultFormatter.unknown(result, message.text);
+  }
+
+  plugin.setDecodeLevel(result, result.decoded);
+  return result;
 }
 
-export function label_4a_variant_3_position(
-  _value: unknown,
-  _args: Record<string, unknown>,
-): unknown {
-  throw new Error(
-    'TODO: port from lib/plugins/Label_4A.ts (variant 3 branch). The ' +
-      'hand-written plugin builds the position from ' +
-      '`(fields[4] + fields[5]).replace(/[ \\.]/g, "")` via ' +
-      'CoordinateUtils.decodeStringCoordinates. The generated plugin ' +
-      'stores the return into result.raw.position.',
-  );
-}
-
-export function label_4a_format(_result: DecodeResult): void {
-  throw new Error(
-    'TODO: port from lib/plugins/Label_4A.ts. label_4a_format must emit ' +
-      'all formatted.items for every variant because the generated ' +
-      'plugin only writes to result.raw.* (no inline ResultFormatter ' +
-      'calls). See lib/plugins/Label_4A.test.ts for the expected items ' +
-      'per variant.',
-  );
-}
+// Format hatch declared in the spec; unused because parse is also custom and
+// the generated wrapper returns directly from the parse hatch. Kept as a
+// no-op to satisfy the codegen-emitted import.
+export function label_4a_format(_result: DecodeResult): void {}

--- a/lib/plugins/escape_hatches/Label_4A_01.ts
+++ b/lib/plugins/escape_hatches/Label_4A_01.ts
@@ -1,0 +1,54 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_4A_01 (01 preamble — Latest New Format).
+ *
+ * Ported from lib/plugins/Label_4A_01.ts. Behavior:
+ *   - Single multiline regex with 9 capture groups.
+ *   - On match: emits state_change (rgx[1] → rgx[2]), callsign (rgx[3]),
+ *     timestamp from rgx[4] + '00', departure (rgx[5]), arrival (rgx[6]),
+ *     altitude (rgx[7] with whitespace stripped from sign), unknown rgx[8],
+ *     temperature (rgx[9] with whitespace stripped from sign).
+ *   - On miss: marks decoded=false and emits message.text as unknown.
+ *   - setDecodeLevel is called with the final decoded flag.
+ */
+export function label_4a_01_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const rgx = message.text.match(
+    /^01([A-Z]{2})([A-Z]{2})\s*(\w+)\/(\d{6})([A-Z]{4})([A-Z]{4})\r\n([+-]\s*\d+)(\d{3}\.\d)([+-]\s*\d+\.\d)/,
+  );
+  if (rgx) {
+    ResultFormatter.state_change(result, rgx[1], rgx[2]);
+    ResultFormatter.callsign(result, rgx[3]);
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(rgx[4] + '00'),
+    );
+    ResultFormatter.departureAirport(result, rgx[5]);
+    ResultFormatter.arrivalAirport(result, rgx[6]);
+    ResultFormatter.altitude(result, Number(rgx[7].replace(/ /g, '')));
+    ResultFormatter.unknown(result, rgx[8]);
+    ResultFormatter.temperature(result, rgx[9].replace(/ /g, ''));
+  } else {
+    result.decoded = false;
+    ResultFormatter.unknown(result, message.text);
+  }
+
+  plugin.setDecodeLevel(result, result.decoded);
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4A_DIS.ts
+++ b/lib/plugins/escape_hatches/Label_4A_DIS.ts
@@ -1,0 +1,41 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_4A_DIS (DIS preamble — Latest New Format).
+ *
+ * Ported from lib/plugins/Label_4A_DIS.ts. Behavior:
+ *   - Splits on ','.
+ *   - Timestamp = fields[1].substring(2) + '00' via convertHHMMSSToTod
+ *     (i.e. drops a 2-char prefix from fields[1] and appends '00').
+ *   - Callsign = fields[2].
+ *   - Text = fields.slice(3).join('') (no separator).
+ *   - Always decoded=true; level inferred from remaining.text.
+ */
+export function label_4a_dis_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const fields = message.text.split(',');
+  ResultFormatter.timestamp(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(fields[1].substring(2) + '00'),
+  );
+  ResultFormatter.callsign(result, fields[2]);
+  ResultFormatter.text(result, fields.slice(3).join(''));
+
+  plugin.setDecodeLevel(result, result.decoded);
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4A_DOOR.ts
+++ b/lib/plugins/escape_hatches/Label_4A_DOOR.ts
@@ -1,0 +1,42 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_4A_DOOR (DOOR preamble — Latest New Format).
+ *
+ * Ported from lib/plugins/Label_4A_DOOR.ts. Behavior:
+ *   - Splits on ' '; expects exactly 3 fields.
+ *   - door_event(door_name = fields[0].split('/')[1], state = fields[1]).
+ *   - Timestamp = fields[2] + '00' via convertHHMMSSToTod.
+ *   - On unexpected field count: decoded=false, emit message.text as unknown.
+ */
+export function label_4a_door_decode(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const fields = message.text.split(' ');
+  if (fields.length === 3) {
+    ResultFormatter.door_event(result, fields[0].split('/')[1], fields[1]);
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[2] + '00'),
+    );
+  } else {
+    result.decoded = false;
+    ResultFormatter.unknown(result, message.text);
+  }
+  plugin.setDecodeLevel(result, result.decoded);
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4A_Slash_01.ts
+++ b/lib/plugins/escape_hatches/Label_4A_Slash_01.ts
@@ -1,0 +1,42 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_4A_Slash_01 (/01 preamble — Latest New Format).
+ *
+ * Ported from lib/plugins/Label_4A_Slash_01.ts. Behavior:
+ *   - If message.text length is exactly 5 and starts with '/01-', emit the
+ *     trailing single char as unknown and mark decoded=true.
+ *   - Otherwise mark decoded=false and emit the whole message as unknown.
+ *   - decodeLevel: 'none' if not decoded, else 'full' when remaining.text
+ *     is empty, otherwise 'partial' (matches the source's hand-rolled logic
+ *     rather than going through setDecodeLevel).
+ */
+export function label_4a_slash_01_decode(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  if (message.text.length === 5 && message.text.substring(0, 4) === '/01-') {
+    ResultFormatter.unknown(result, message.text.substring(4));
+  } else {
+    result.decoded = false;
+    ResultFormatter.unknown(result, message.text);
+  }
+
+  if (result.decoded) {
+    if (!result.remaining.text) result.decoder.decodeLevel = 'full';
+    else result.decoder.decodeLevel = 'partial';
+  } else {
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4N.ts
+++ b/lib/plugins/escape_hatches/Label_4N.ts
@@ -1,0 +1,72 @@
+// Escape-hatch port of lib/plugins/Label_4N.ts decode().
+// Two variants dispatched by raw text length (51) vs CSV field count (33).
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { ResultFormatter, CoordinateUtils } from '@airframes/ads-runtime-ts';
+
+export function label_4n_decode(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const text = message.text;
+  const fields = text.split(',');
+
+  if (text.length === 51) {
+    // variant 1
+    result.raw.day = text.substring(0, 2);
+    ResultFormatter.departureAirport(result, text.substring(8, 11));
+    ResultFormatter.arrivalAirport(result, text.substring(13, 16));
+    ResultFormatter.position(
+      result,
+      CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+        text.substring(30, 45).replace(/^(.)0/, '$1'),
+      ),
+    );
+    ResultFormatter.altitude(result, Number(text.substring(48, 51)) * 100);
+    ResultFormatter.unknownArr(
+      result,
+      [text.substring(2, 4), text.substring(19, 29)],
+      ' ',
+    );
+  } else if (fields.length === 33) {
+    // variant 2
+    result.raw.date = fields[3];
+    if (fields[1] === 'B') {
+      ResultFormatter.position(result, {
+        latitude: Number(fields[4]),
+        longitude: Number(fields[5]),
+      });
+      ResultFormatter.altitude(result, Number(fields[6]));
+    }
+    ResultFormatter.departureAirport(result, fields[8]);
+    ResultFormatter.arrivalAirport(result, fields[9]);
+    ResultFormatter.alternateAirport(result, fields[10]);
+    ResultFormatter.arrivalRunway(result, fields[11].split('/')[0]);
+    if (fields[12].length > 1) {
+      ResultFormatter.alternateRunway(result, fields[12].split('/')[0]);
+    }
+    ResultFormatter.checksum(result, parseInt(fields[32], 16));
+    ResultFormatter.unknownArr(
+      result,
+      [...fields.slice(1, 3), fields[7], ...fields.slice(13, 32)].filter(
+        (f) => f != '',
+      ),
+    );
+  } else {
+    result.decoded = false;
+    ResultFormatter.unknown(result, text);
+  }
+
+  if (result.decoded) {
+    if (!result.remaining.text) result.decoder.decodeLevel = 'full';
+    else result.decoder.decodeLevel = 'partial';
+  } else {
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4T_AGFSR.ts
+++ b/lib/plugins/escape_hatches/Label_4T_AGFSR.ts
@@ -1,0 +1,56 @@
+// Escape-hatch port of lib/plugins/Label_4T_AGFSR.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_4t_agfsr_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const data = message.text.substring(5).split('/');
+
+  if (!message.text.startsWith('AGFSR') || data.length !== 20) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 4T message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.flightNumber(result, data[0].trim());
+  ResultFormatter.departureDay(result, Number(data[1]));
+  ResultFormatter.arrivalDay(result, Number(data[2]));
+  ResultFormatter.departureAirport(result, data[3].substring(0, 3), 'IATA');
+  ResultFormatter.arrivalAirport(result, data[3].substring(3), 'IATA');
+  ResultFormatter.timestamp(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(data[4].substring(0, 4)),
+  );
+  ResultFormatter.unknown(result, data[5], '/');
+  const lat = data[6].substring(0, 7);
+  const lon = data[6].substring(7, 15);
+  ResultFormatter.position(result, {
+    latitude:
+      CoordinateUtils.getDirection(lat[6]) * Number(lat.substring(0, 2)) +
+      Number(lat.substring(2, 6)) / 60,
+    longitude:
+      CoordinateUtils.getDirection(lon[7]) * Number(lon.substring(0, 3)) +
+      Number(lon.substring(3, 7)) / 60,
+  });
+  ResultFormatter.altitude(result, 100 * Number(data[7]));
+  ResultFormatter.unknownArr(result, data.slice(8), '/');
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_4T_ETA.ts
+++ b/lib/plugins/escape_hatches/Label_4T_ETA.ts
@@ -1,0 +1,39 @@
+// Escape-hatch port of lib/plugins/Label_4T_ETA.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_4t_eta_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const data = message.text.substring(3).split('/');
+
+  if (!message.text.startsWith('ETA') || data.length !== 3) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 4T message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.flightNumber(result, data[0].trim());
+  ResultFormatter.departureDay(result, Number(data[1]));
+  const etaData = data[2].split(' ');
+  ResultFormatter.arrivalDay(result, Number(etaData[0]));
+  ResultFormatter.arrivalAirport(result, etaData[1], 'IATA');
+  ResultFormatter.eta(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(etaData[2].substring(0, 4)),
+  );
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_58.ts
+++ b/lib/plugins/escape_hatches/Label_58.ts
@@ -1,0 +1,47 @@
+// Escape-hatch port of lib/plugins/Label_58.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_58_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const data = message.text.split('/');
+  if (data.length === 8) {
+    ResultFormatter.flightNumber(result, data[0]);
+    ResultFormatter.day(result, Number(data[1]));
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(data[2]),
+    );
+    const lat = data[3];
+    const lon = data[4];
+    ResultFormatter.position(result, {
+      latitude: CoordinateUtils.getDirection(lat[0]) * Number(lat.substring(1)),
+      longitude: CoordinateUtils.getDirection(lon[0]) * Number(lon.substring(1)),
+    });
+    ResultFormatter.altitude(result, Number(data[5]));
+    ResultFormatter.unknown(result, data[6], '/');
+    ResultFormatter.unknown(result, data[7], '/');
+  } else {
+    if (options.debug) {
+      console.log(`Decoder: Unknown 58 message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_5Z_Slash.ts
+++ b/lib/plugins/escape_hatches/Label_5Z_Slash.ts
@@ -1,0 +1,148 @@
+// Escape-hatch port of lib/plugins/Label_5Z_Slash.ts decode().
+// Multi-format airline-defined downlink with magic-string discriminants.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+const descriptions: Record<string, string> = {
+  B1: 'Request Weight and Balance',
+  B3: 'Request Departure Clearance',
+  CD: 'Weight and Balance',
+  CG: 'Request Pre-departure clearance, PDC',
+  CM: 'Crew Scheduling',
+  C3: 'Off Message',
+  C4: 'Flight Dispatch',
+  C5: 'Maintenance Message',
+  C6: 'Customer Service',
+  10: 'PIREP',
+  C11: 'International PIREP',
+  DS: 'Late Message',
+  D3: 'Holding Pattern Message',
+  D6: 'From-To + Date',
+  D7: 'From-To + Alternate + Time',
+  EO: 'In Range',
+  ET: 'Expected Time',
+  PW: 'Position Weather',
+  RL: 'Request Release',
+  R3: 'Request HOWGOZIT Message',
+  R4: 'Request the Latest POSBD',
+  TC: 'From-To Fuel',
+  WB: 'From-To',
+  W1: 'Request Weather for City',
+};
+
+export function label_5z_slash_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const lines = message.text.split('\r\n');
+  if (lines[0] === '/TXT') {
+    // not UA, but starts with `/`
+    ResultFormatter.text(result, lines.slice(1).join('\r\n'));
+    result.decoded = true;
+    result.decoder.decodeLevel = 'full';
+    return result;
+  }
+
+  const data = lines[0].split('/');
+  const header = data[1].split(' '); //data[0] is blank
+  const type = header[0];
+  const typeDescription = descriptions[type];
+
+  if (typeDescription) {
+    result.raw.airline = 'United Airlines';
+    result.formatted.items.push({
+      type: 'airline',
+      code: 'AIRLINE',
+      label: 'Airline',
+      value: 'United Airlines',
+    });
+    result.raw.message_type = type;
+    result.formatted.items.push({
+      type: 'message_type',
+      code: 'MSG_TYPE',
+      label: 'Message Type',
+      value: `${typeDescription} (${type})`,
+    });
+
+    if (type === 'B3' && data[1] === 'B3 TO DATA REQ    ') {
+      const info = data[2].split(' ');
+      //info[0] is blank
+      ResultFormatter.departureAirport(result, info[1]);
+      ResultFormatter.arrivalAirport(result, info[2]);
+      result.raw.day = Number(info[3]);
+      ResultFormatter.timestamp(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(info[4]),
+      );
+      ResultFormatter.arrivalRunway(result, info[5].slice(1));
+      ResultFormatter.unknownArr(result, data.slice(3), '/');
+    } else if (type === 'B3') {
+      ResultFormatter.departureAirport(
+        result,
+        header[1].substring(0, 3),
+        'IATA',
+      );
+      ResultFormatter.arrivalAirport(result, header[1].substring(3), 'IATA');
+      result.raw.day = Number(header[2]);
+      ResultFormatter.arrivalRunway(result, header[3].slice(1));
+      if (header.length > 4) {
+        ResultFormatter.unknownArr(result, header.slice(4), '/');
+      }
+    } else if (type === 'C3' && data[1] === 'C3 GATE REQ       ') {
+      const info = data[2].split(' ');
+      //info[0] is blank
+      ResultFormatter.departureAirport(result, info[1]);
+      ResultFormatter.arrivalAirport(result, info[2]);
+      result.raw.day = Number(info[3]);
+      ResultFormatter.timestamp(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(info[4]),
+      );
+      ResultFormatter.unknownArr(result, info.slice(5), ' ');
+    } else if (type === 'C3') {
+      ResultFormatter.departureAirport(
+        result,
+        header[1].substring(0, 3),
+        'IATA',
+      );
+      ResultFormatter.arrivalAirport(result, header[1].substring(3), 'IATA');
+    } else if (type === 'ET') {
+      const airports = data[2].split(' ');
+      // aiports[0] is blank
+      ResultFormatter.departureAirport(result, airports[1]);
+      ResultFormatter.arrivalAirport(result, airports[2]);
+      result.raw.day = Number(airports[3]);
+      ResultFormatter.timestamp(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(airports[4]),
+      );
+
+      const estimates = data[3].split(' ');
+      ResultFormatter.eta(
+        result,
+        DateTimeUtils.convertHHMMSSToTod(estimates[1]),
+      );
+      ResultFormatter.unknown(result, estimates[2]);
+    } else {
+      if (options.debug) {
+        console.log(`Decoder: Unkown 5Z RDC format: ${message.text}`);
+      }
+    }
+    result.decoded = true;
+    result.decoder.decodeLevel = result.remaining.text ? 'partial' : 'full';
+  } else {
+    // Unknown
+    if (options.debug) {
+      console.log(`Decoder: Unknown 5Z message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_80.ts
+++ b/lib/plugins/escape_hatches/Label_80.ts
@@ -1,0 +1,200 @@
+// Escape-hatch port of lib/plugins/Label_80.ts decode().
+// Airline-defined position report — CSV one-liner OR tag-prefixed multi-line.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_80_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  const lines = message.text.split(/\r?\n/);
+  if (lines.length === 1 && lines[0].includes(',')) {
+    parseCsvFormat(lines[0], result);
+  } else {
+    const header = lines[0].trim();
+    const headerParts = header.split(',');
+    for (let i = 0; i < headerParts.length - 1; i++) {
+      const moreFields = headerParts[i].split('/');
+      for (const more of moreFields) {
+        parseTags(more.trim(), result);
+      }
+    }
+
+    parseHeader(headerParts[headerParts.length - 1].trim(), result);
+
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      const parts = line.split('/');
+      for (const part of parts) {
+        parseTags(part.trim(), result);
+      }
+    }
+  }
+
+  if (result.formatted.items.length > 0) {
+    // Equivalent to plugin.setDecodeLevel(result, true)
+    result.decoded = true;
+    result.decoder.decodeLevel = result.remaining.text ? 'partial' : 'full';
+  }
+
+  return result;
+}
+
+function parseHeader(header: string, results: DecodeResult) {
+  //3N01 POSRPT 0581/27 KIAD/MSLP .N962AV/04H 11:02
+  const fields = header.split('/');
+  if (fields.length < 3) {
+    ResultFormatter.unknown(results, header, '/');
+    return;
+  }
+  const msgInfo = fields[0].split(/\s+/);
+  if (msgInfo.length === 3) {
+    ResultFormatter.unknownArr(results, msgInfo.slice(0, 2), ' ');
+    ResultFormatter.flightNumber(results, msgInfo[2]);
+  } else {
+    ResultFormatter.unknown(results, header, '/');
+    return;
+  }
+
+  const otherInfo1 = fields[1].split(/\s+/);
+  if (otherInfo1.length === 2) {
+    ResultFormatter.day(results, parseInt(otherInfo1[0], 10));
+    ResultFormatter.departureAirport(results, otherInfo1[1]);
+  } else {
+    ResultFormatter.unknownArr(results, otherInfo1, ' ');
+  }
+
+  const otherInfo2 = fields[2].split(/\s+/);
+  if (otherInfo2.length === 2) {
+    ResultFormatter.arrivalAirport(results, otherInfo2[0]);
+    ResultFormatter.tail(results, otherInfo2[1].replace('.', ''));
+  } else {
+    ResultFormatter.unknownArr(results, otherInfo2, ' ');
+  }
+
+  if (fields.length > 3) {
+    ResultFormatter.unknownArr(results, fields.slice(3), '/');
+  }
+}
+
+function parseTags(part: string, results: DecodeResult) {
+  const kvPair = part.split(/\s+/);
+  if (kvPair.length < 2) {
+    ResultFormatter.unknown(results, part, '/');
+    return;
+  }
+  const tag = kvPair[0];
+  const val = kvPair.slice(1).join(' ');
+
+  switch (tag) {
+    case 'POS': {
+      // don't use decodeStringCoordinates because of different position format
+      const posRegex = /^(?<latd>[NS])(?<lat>.+)(?<lngd>[EW])(?<lng>.+)/;
+      const posResult = val.match(posRegex);
+      const lat =
+        Number(posResult?.groups?.lat) *
+        (posResult?.groups?.latd === 'S' ? -1 : 1);
+      const lon =
+        Number(posResult?.groups?.lng) *
+        (posResult?.groups?.lngd === 'W' ? -1 : 1);
+      const position = {
+        latitude: Number.isInteger(lat) ? lat / 1000 : lat / 100,
+        longitude: Number.isInteger(lon) ? lon / 1000 : lon / 100,
+      };
+      ResultFormatter.position(results, position);
+      break;
+    }
+    case 'ALT':
+      ResultFormatter.altitude(results, parseInt(val.replace('+', ''), 10));
+      break;
+    case 'FL': // Handle "FL 360"
+      ResultFormatter.altitude(results, parseInt(val, 10) * 100);
+      break;
+    case 'MCH':
+      ResultFormatter.mach(results, parseInt(val, 10) / 1000);
+      break;
+    case 'SPD':
+      ResultFormatter.groundspeed(results, parseInt(val, 10));
+      break;
+    case 'TAS':
+      ResultFormatter.airspeed(results, parseInt(val, 10));
+      break;
+    case 'SAT':
+      ResultFormatter.temperature(results, val);
+      break;
+    case 'FB':
+      // ignoring, assuming FOB and avoiding duplicates.
+      break;
+    case 'FOB':
+      // Strip non-numeric like 'N' in 'N009414'
+      ResultFormatter.currentFuel(
+        results,
+        parseInt(val.replace(/\D/g, ''), 10),
+      );
+      break;
+    case 'UTC':
+      ResultFormatter.timestamp(results, DateTimeUtils.convertHHMMSSToTod(val));
+      break;
+    case 'ETA': {
+      const hhmm = val.split('.')[0].replace(':', '');
+      ResultFormatter.eta(results, DateTimeUtils.convertHHMMSSToTod(hhmm));
+      break;
+    }
+    case 'HDG':
+      ResultFormatter.heading(results, parseInt(val, 10));
+      break;
+    case 'NWYP':
+      results.raw.next_waypoint = val;
+      break;
+    case 'SWN':
+      // wind speed, do nothing for
+      ResultFormatter.unknown(results, part, '/');
+      break;
+    case 'DWN':
+      // wind direction, do nothing for now
+      ResultFormatter.unknown(results, part, '/');
+      break;
+    case 'AD':
+      // do nothing, as it shows in the header
+      break;
+    default:
+      ResultFormatter.unknown(results, part, '/');
+  }
+}
+
+function parseCsvFormat(text: string, results: DecodeResult) {
+  const csvParts = text.split(',');
+  if (csvParts.length !== 9) {
+    return;
+  }
+  const header = csvParts[0].trim().split(/\s+/);
+  ResultFormatter.unknown(results, header[0], ' ');
+  ResultFormatter.unknown(results, header[1], ' ');
+  ResultFormatter.position(
+    results,
+    CoordinateUtils.decodeStringCoordinates(header[2]),
+  );
+  ResultFormatter.unknown(results, csvParts[1]);
+  ResultFormatter.timestamp(
+    results,
+    DateTimeUtils.convertHHMMSSToTod(csvParts[2]),
+  );
+  ResultFormatter.unknownArr(results, csvParts.slice(4, 6), ',');
+  ResultFormatter.temperature(
+    results,
+    (
+      (csvParts[6].charAt(0) === 'M' ? -1 : 1) *
+      parseInt(csvParts[6].slice(1), 10)
+    ).toString(),
+  );
+  ResultFormatter.airspeed(results, parseInt(csvParts[7], 10));
+  ResultFormatter.currentFuel(results, parseInt(csvParts[8], 10));
+}

--- a/lib/plugins/escape_hatches/Label_83.ts
+++ b/lib/plugins/escape_hatches/Label_83.ts
@@ -1,0 +1,77 @@
+// Escape-hatch port of lib/plugins/Label_83.ts decode().
+// Three discriminated variants keyed on message prefix.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+export function label_83_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.decoded = true;
+  const text = message.text;
+
+  if (text.substring(0, 10) === '4DH3 ETAT2') {
+    // variant 2
+    const fields = text.split(/\s+/);
+    if (fields[2].length > 5) {
+      result.raw.day = fields[2].substring(5);
+    }
+    ResultFormatter.unknown(result, fields[2].substring(0, 4));
+    const subfields = fields[3].split('/');
+    ResultFormatter.departureAirport(result, subfields[0]);
+    ResultFormatter.arrivalAirport(result, subfields[1]);
+    ResultFormatter.tail(result, fields[4].replace(/\./g, ''));
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(fields[6] + '00'),
+    );
+  } else if (text.substring(0, 5) === '001PR') {
+    // variant 3
+    result.raw.day = text.substring(5, 7);
+    const position = CoordinateUtils.decodeStringCoordinatesDecimalMinutes(
+      text.substring(13, 28).replace(/\./g, ''),
+    );
+    if (position) {
+      ResultFormatter.position(result, position);
+    }
+    ResultFormatter.altitude(result, Number(text.substring(28, 33)));
+    ResultFormatter.unknown(result, text.substring(33));
+  } else {
+    const fields = text.replace(/\s/g, '').split(',');
+    if (fields.length === 9) {
+      // variant 1
+      ResultFormatter.departureAirport(result, fields[0]);
+      ResultFormatter.arrivalAirport(result, fields[1]);
+      result.raw.day = fields[2].substring(0, 2);
+      result.raw.time = fields[2].substring(2);
+      ResultFormatter.position(result, {
+        latitude: Number(fields[3].replace(/\s/g, '')),
+        longitude: Number(fields[4].replace(/\s/g, '')),
+      });
+      ResultFormatter.altitude(result, Number(fields[5]));
+      ResultFormatter.groundspeed(result, Number(fields[6]));
+      ResultFormatter.heading(result, Number(fields[7]));
+      ResultFormatter.unknown(result, fields[8]);
+    } else {
+      result.decoded = false;
+      ResultFormatter.unknown(result, text);
+    }
+  }
+
+  if (result.decoded) {
+    if (!result.remaining.text) result.decoder.decodeLevel = 'full';
+    else result.decoder.decodeLevel = 'partial';
+  } else {
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_8E.ts
+++ b/lib/plugins/escape_hatches/Label_8E.ts
@@ -1,0 +1,35 @@
+// Escape-hatch port of lib/plugins/Label_8E.ts decode().
+// NOTE: TS unconditionally marks decoded=true even if regex doesn't match.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_8e_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Style: EGSS,1618
+  // Match: arrival_icao,arrival_eta
+  const regex = /^(?<arrival_icao>\w{4}),(?<arrival_eta>\d{4})$/;
+  const results = message.text.match(regex);
+  if (results?.groups) {
+    if (options.debug) {
+      console.log('Label 8E ETA: groups');
+      console.log(results.groups);
+    }
+
+    ResultFormatter.eta(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(results.groups.arrival_eta),
+    );
+    ResultFormatter.arrivalAirport(result, results.groups.arrival_icao);
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_B6_Forwardslash.ts
+++ b/lib/plugins/escape_hatches/Label_B6_Forwardslash.ts
@@ -1,0 +1,18 @@
+// Escape-hatch port of lib/plugins/Label_B6.ts decode().
+// TS source is a placeholder: returns defaultResult with description only;
+// no fields parsed, decoded stays false. Preserves the debug log path.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+
+export function label_b6_forwardslash_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (options.debug) {
+    console.log('CPDLC: ' + message);
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_ColonComma.ts
+++ b/lib/plugins/escape_hatches/Label_ColonComma.ts
@@ -1,0 +1,25 @@
+// Escape-hatch port of lib/plugins/Label_ColonComma.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+
+export function label_colon_comma_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.raw.frequency = Number(message.text) / 1000;
+
+  result.formatted.items.push({
+    type: 'frequency',
+    label: 'Frequency',
+    value: `${result.raw.frequency} MHz`,
+    code: 'FREQ',
+  });
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_ATIS.ts
+++ b/lib/plugins/escape_hatches/Label_H1_ATIS.ts
@@ -1,0 +1,64 @@
+// Escape-hatch port of lib/plugins/Label_H1_ATIS.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_h1_atis_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Pattern: L[2-digit seq]A[flight]/[facility].TI2/[code][airport][checksum]
+  const regex =
+    /^L(\d{2})A([A-Z0-9]+)\/([A-Z]{4})\.TI2\/(\d{3})([A-Z]{4})([A-F0-9]+)$/;
+  const match = message.text.match(regex);
+
+  if (!match) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 ATIS message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  // const seq = match[1]; // not used
+  const flight = match[2];
+  const facility = match[3];
+  const code = match[4];
+  const airport = match[5];
+  const checksum = match[6];
+
+  ResultFormatter.flightNumber(result, flight);
+  ResultFormatter.arrivalAirport(result, facility);
+
+  result.raw.atis_code = code;
+  result.formatted.items.push({
+    type: 'atis',
+    code: 'ATIS_CODE',
+    label: 'ATIS Code',
+    value: code,
+  });
+
+  // The airport in the TI2 section
+  if (airport !== facility) {
+    result.raw.atis_airport = airport;
+    result.formatted.items.push({
+      type: 'icao',
+      code: 'ATIS_ARPT',
+      label: 'ATIS Airport',
+      value: airport,
+    });
+  }
+
+  // Checksum
+  ResultFormatter.checksum(result, parseInt(checksum, 16));
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_EZF.ts
+++ b/lib/plugins/escape_hatches/Label_H1_EZF.ts
@@ -1,0 +1,105 @@
+// Escape-hatch port of lib/plugins/Label_H1_EZF.ts decode().
+// Multi-line load-sheet parser.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_h1_ezf_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const lines = message.text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length < 2 || lines[0] !== 'EZF') {
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 EZF message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const loadsheet: Record<string, string> = {};
+  const unknowns: string[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('-')) {
+      const kvMatch = line.match(/^-([^/]+)\/(.+)$/);
+      if (kvMatch) {
+        loadsheet[kvMatch[1]] = kvMatch[2];
+      } else {
+        unknowns.push(line);
+      }
+    } else if (i === 1) {
+      // Second line is the flight identifier, e.g. NO0246/10/EI-NEO
+      const idParts = line.split('/');
+      if (idParts.length >= 1) {
+        ResultFormatter.flightNumber(result, idParts[0]);
+      }
+      if (idParts.length >= 3) {
+        ResultFormatter.tail(result, idParts[2]);
+      }
+      // Remaining parts of identifier line
+      if (idParts.length >= 2) {
+        // idParts[1] is day or other info - store but don't format
+      }
+    } else if (i === 2) {
+      // Third line typically contains config info, e.g. /C28Y331/3/9
+      unknowns.push(line);
+    } else {
+      unknowns.push(line);
+    }
+  }
+
+  // Extract known fields from loadsheet
+  if (loadsheet['SCT']) {
+    const route = loadsheet['SCT'].split('-');
+    if (route.length === 2) {
+      ResultFormatter.departureAirport(result, route[0], 'IATA');
+      ResultFormatter.arrivalAirport(result, route[1], 'IATA');
+    }
+  }
+
+  // Store all loadsheet data in raw
+  result.raw.loadsheet = loadsheet;
+
+  // Format key loadsheet items
+  const formatFields: [string, string, string][] = [
+    ['STD', 'Scheduled Time of Departure', 'std'],
+    ['FLT STATUS', 'Flight Status', 'flight_status'],
+    ['UOM', 'Unit of Measure', 'uom'],
+    ['ZFW', 'Zero Fuel Weight', 'zfw'],
+    ['PAX', 'Passengers', 'pax'],
+    ['TOW', 'Takeoff Weight', 'tow'],
+    ['DOW', 'Dry Operating Weight', 'dow'],
+    ['FWT', 'Fuel Weight', 'fuel_weight'],
+  ];
+
+  for (const [key, label, code] of formatFields) {
+    if (loadsheet[key]) {
+      result.formatted.items.push({
+        type: 'loadsheet',
+        code: code.toUpperCase(),
+        label: label,
+        value: loadsheet[key],
+      });
+    }
+  }
+
+  if (unknowns.length > 0) {
+    ResultFormatter.unknownArr(result, unknowns, '\n');
+  }
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_FLR.ts
+++ b/lib/plugins/escape_hatches/Label_H1_FLR.ts
@@ -1,0 +1,60 @@
+// Escape-hatch port of lib/plugins/Label_H1_FLR.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_h1_flr_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split('/FR');
+
+  if (parts.length > 1) {
+    // decode header
+    const fields = parts[0].split('/');
+    // 0 is the msg type
+    for (let i = 1; i < fields.length; i++) {
+      const field = fields[i];
+      ResultFormatter.unknown(result, field, '/');
+    }
+
+    const data = parts[1].substring(0, 20);
+    const msg = parts[1].substring(20);
+    const datetime = data.substring(0, 12); // YYMMDDHHMMSS (SS might be next 2 chars)
+    const date =
+      datetime.substring(4, 6) +
+      datetime.substring(2, 4) +
+      datetime.substring(0, 2);
+
+    ResultFormatter.unknown(result, data.substring(12), '/');
+    result.raw.message_timestamp = DateTimeUtils.convertDateTimeToEpoch(
+      datetime.substring(6),
+      date,
+    );
+    // TODO: decode further
+    result.raw.fault_message = msg;
+    result.formatted.items.push({
+      type: 'fault',
+      code: 'FR',
+      label: 'Fault Report',
+      value: result.raw.fault_message as string,
+    });
+
+    // Equivalent to plugin.setDecodeLevel(result, true, 'partial')
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    // Equivalent to plugin.failUnknown(result, message.text, options)
+    if (options.debug) {
+      console.log(`Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_M_POS.ts
+++ b/lib/plugins/escape_hatches/Label_H1_M_POS.ts
@@ -1,0 +1,83 @@
+// Escape-hatch port of lib/plugins/Label_H1_M_POS.ts decode().
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+export function label_h1_m_pos_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  // Match M[2-digit seq]A[airline 2-char][flight 4-digit][origin],[dest],[DDHHMM],[lat],[lon],[alt],[hdg],...
+  const headerRegex = /^M(\d{2})A([A-Z]{2})(\d{4})/;
+  const headerMatch = message.text.match(headerRegex);
+
+  if (!headerMatch) {
+    return failUnknown(result, message.text, options);
+  }
+
+  const airline = headerMatch[2];
+  const flightNum = headerMatch[3];
+  const afterHeader = message.text.substring(headerMatch[0].length);
+  const fields = afterHeader.split(',');
+
+  // We expect at least: origin, dest, DDHHMM, lat, lon, alt, hdg
+  if (fields.length < 7) {
+    return failUnknown(result, message.text, options);
+  }
+
+  ResultFormatter.flightNumber(result, `${airline}${flightNum}`);
+  ResultFormatter.departureAirport(result, fields[0]);
+  ResultFormatter.arrivalAirport(result, fields[1]);
+
+  // DDHHMM timestamp
+  const timestamp = fields[2].trim();
+  if (timestamp.length === 6) {
+    const day = Number(timestamp.substring(0, 2));
+    const tod = DateTimeUtils.convertHHMMSSToTod(
+      timestamp.substring(2) + '00',
+    );
+    ResultFormatter.day(result, day);
+    ResultFormatter.timestamp(result, tod);
+  }
+
+  // Latitude and longitude (trim spaces, e.g. "- 4.9985")
+  const lat = parseFloat(fields[3].replace(/\s/g, ''));
+  const lon = parseFloat(fields[4].replace(/\s/g, ''));
+  ResultFormatter.position(result, { latitude: lat, longitude: lon });
+
+  // Altitude
+  const alt = Number(fields[5]);
+  ResultFormatter.altitude(result, alt);
+
+  // Heading
+  const hdg = Number(fields[6]);
+  ResultFormatter.heading(result, hdg);
+
+  // Remaining fields as unknown
+  if (fields.length > 7) {
+    ResultFormatter.unknownArr(result, fields.slice(7));
+  }
+
+  // Equivalent to plugin.setDecodeLevel(result, true, fields.length > 7 ? 'partial' : 'full')
+  result.decoded = true;
+  result.decoder.decodeLevel = fields.length > 7 ? 'partial' : 'full';
+
+  return result;
+}
+
+function failUnknown(
+  result: DecodeResult,
+  text: string,
+  options: Options,
+): DecodeResult {
+  if (options.debug) {
+    console.log(`Unknown message: ${text}`);
+  }
+  ResultFormatter.unknown(result, text);
+  result.decoded = false;
+  result.decoder.decodeLevel = 'none';
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_OFP.ts
+++ b/lib/plugins/escape_hatches/Label_H1_OFP.ts
@@ -1,0 +1,92 @@
+// Escape-hatch port of lib/plugins/Label_H1_OFP.ts decode().
+// Delegates to parseIcaoFpl (icao_fpl_utils.ts) — a multi-stage ICAO
+// flight-plan parser with state-machine bracket matching.
+
+import type { DecodeResult, Message, Options } from '@airframes/ads-runtime-ts';
+import { DecoderPlugin } from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+import { parseIcaoFpl } from '../../utils/icao_fpl_utils';
+
+export function label_h1_ofp_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  if (!message.text.includes('(FPL-')) {
+    if (options.debug) {
+      console.log(`Decoder: No FPL block found in message`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const fpl = parseIcaoFpl(message.text);
+  if (!fpl) {
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  // Populate decoded results
+  ResultFormatter.callsign(result, fpl.callsign);
+
+  result.formatted.items.push({
+    type: 'aircraft_type',
+    code: 'ACFT',
+    label: 'Aircraft Type',
+    value: fpl.aircraftType,
+  });
+
+  if (fpl.departure) {
+    ResultFormatter.departureAirport(result, fpl.departure);
+  }
+
+  if (fpl.destination) {
+    ResultFormatter.arrivalAirport(result, fpl.destination);
+  }
+
+  if (fpl.alternates.length > 0) {
+    ResultFormatter.alternateAirport(result, fpl.alternates[0]);
+  }
+
+  if (fpl.route) {
+    ResultFormatter.route(result, fpl.route);
+  }
+
+  if (fpl.otherInfo.REG) {
+    ResultFormatter.tail(result, fpl.otherInfo.REG);
+  }
+
+  const rulesMap: Record<string, string> = {
+    I: 'IFR',
+    V: 'VFR',
+    Y: 'IFR/VFR',
+    Z: 'VFR/IFR',
+  };
+  const rulesDesc = rulesMap[fpl.flightRules] || fpl.flightRules;
+  result.formatted.items.push({
+    type: 'flight_rules',
+    code: 'RULES',
+    label: 'Flight Rules',
+    value: rulesDesc,
+  });
+
+  result.formatted.items.push({
+    type: 'cruise',
+    code: 'CRUISE',
+    label: 'Cruise Speed/Level',
+    value: `${fpl.cruiseSpeed} ${fpl.cruiseLevel}`,
+  });
+
+  // Store raw FPL data
+  result.raw.icao_fpl = fpl;
+
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_OHMA.ts
+++ b/lib/plugins/escape_hatches/Label_H1_OHMA.ts
@@ -1,0 +1,50 @@
+import type { DecodeResult } from '@airframes/ads-runtime-ts';
+
+/**
+ * Field-level hatch for the OHMA `ohma` field.
+ *
+ * The legacy plugin stored the inflated JSON text on `decodeResult.raw.ohma`
+ * and pushed a pretty-printed version into `formatted.items`. The DSL
+ * pipeline puts the inflated JSON text into `$json_text`, so the field
+ * hatch's only job is to pass it through (the formatter hatch handles
+ * the pretty-printing).
+ */
+export function ohma_unwrap_message(value: unknown, _args: Record<string, unknown>): unknown {
+  // Preserve original behavior: raw.ohma is the raw inflated JSON text.
+  return typeof value === 'string' ? value : String(value);
+}
+
+/**
+ * Formatter-level hatch for the OHMA Downlink item.
+ *
+ * Re-derives the formatted string from `result.raw.ohma` using the same
+ * two-stage JSON unwrap the legacy plugin used:
+ *   1. Parse the outer envelope, take `.message` (fall back to raw text).
+ *   2. Parse that as JSON, then JSON.stringify(_, null, 2) for display
+ *      (fall back to the unwrapped string).
+ */
+export function ohma_message_item(result: DecodeResult): void {
+  const jsonText = typeof result.raw.ohma === 'string' ? result.raw.ohma : String(result.raw.ohma ?? '');
+
+  let jsonMessage: string;
+  try {
+    jsonMessage = JSON.parse(jsonText).message;
+  } catch {
+    jsonMessage = jsonText;
+  }
+
+  let formattedMsg: string;
+  try {
+    const ohmaMsg = JSON.parse(jsonMessage);
+    formattedMsg = JSON.stringify(ohmaMsg, null, 2);
+  } catch {
+    formattedMsg = jsonMessage;
+  }
+
+  result.formatted.items.push({
+    type: 'ohma',
+    code: 'OHMA',
+    label: 'OHMA Downlink',
+    value: formattedMsg,
+  });
+}

--- a/lib/plugins/escape_hatches/Label_H1_Paren.ts
+++ b/lib/plugins/escape_hatches/Label_H1_Paren.ts
@@ -1,0 +1,72 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_H1_Paren.
+ *
+ * Ports the original regex-driven position report parse. The match groups
+ * are deg-min lat/lon (NSDM / EWDM), HHMMSS time-of-day, FLxxx altitude
+ * (multiplied by 100), decimal fuel (in metric tons via parseFloat), and
+ * decimal mach. A literal 'RMK' is appended as an unknown marker for
+ * parity. Non-matching input yields `decoded: false` with no remaining
+ * text emitted (mirrors the legacy plugin).
+ */
+export function label_h1_paren_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  if (!message.text || !message.text.startsWith('(')) {
+    result.decoded = false;
+    return result;
+  }
+
+  const regex =
+    /^\(POS-(?<flight>\w+)\s+(?<lat>-?\d{4,5}[NS])(?<lon>\d{5}[EW])\/(?<timestamp>\d{6})\s+F(?<alt>\d{3})\r?\nRMK\/FUEL\s+(?<fuel>\d{2,3}\.\d)\s+M(?<mach>\d\.\d{2})\)/;
+
+  const match = message.text.match(regex);
+  if (match && match.groups) {
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+    result.formatted.description = 'Position Report';
+
+    ResultFormatter.flightNumber(result, match.groups.flight);
+    ResultFormatter.position(result, {
+      latitude: parseLat(match.groups.lat),
+      longitude: parseLon(match.groups.lon),
+    });
+    ResultFormatter.timestamp(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(match.groups.timestamp),
+    );
+    ResultFormatter.altitude(result, parseInt(match.groups.alt, 10) * 100);
+    ResultFormatter.currentFuel(result, parseFloat(match.groups.fuel));
+    ResultFormatter.mach(result, parseFloat(match.groups.mach));
+    ResultFormatter.unknown(result, 'RMK');
+  }
+  return result;
+}
+
+function parseLat(latStr: string): number {
+  const match = latStr.match(/(-?)(\d{2})(\d{2})([NS])/);
+  if (!match) return NaN;
+  const deg = parseInt(match[2]);
+  const min = parseInt(match[3]);
+  const sign = match[4] === 'S' ? -1 : 1;
+  return sign * (deg + min / 60);
+}
+
+function parseLon(lonStr: string): number {
+  const match = lonStr.match(/(\d{3})(\d{2})([EW])/);
+  if (!match) return NaN;
+  const deg = parseInt(match[1]);
+  const min = parseInt(match[2]);
+  const sign = match[3] === 'W' ? -1 : 1;
+  return sign * (deg + min / 60);
+}

--- a/lib/plugins/escape_hatches/Label_H1_StarPOS.ts
+++ b/lib/plugins/escape_hatches/Label_H1_StarPOS.ts
@@ -1,0 +1,57 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_H1_StarPOS.
+ *
+ * The message is a fixed 43-character "*POS" report with packed substring
+ * fields: month, day, HHMM time-of-day, deg-min lat/lon, altitude, and
+ * trailing unknown bytes. Any deviation from the length or prefix falls
+ * back to an unknown report.
+ */
+export function label_h1_starpos_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const msg = message.text;
+  if (msg.length !== 43 || !msg.startsWith('*POS')) {
+    if (options.debug) {
+      console.log(`Decoder: Unknown H1 message: ${msg}`);
+    }
+    ResultFormatter.unknown(result, msg);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  ResultFormatter.month(result, Number(msg.substring(4, 6)));
+  ResultFormatter.day(result, Number(msg.substring(6, 8)));
+  ResultFormatter.timestamp(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(msg.substring(8, 12)),
+  );
+  ResultFormatter.position(result, {
+    latitude:
+      CoordinateUtils.getDirection(msg.substring(12, 13)) *
+      (Number(msg.substring(13, 15)) + Number(msg.substring(15, 17)) / 60),
+    longitude:
+      CoordinateUtils.getDirection(msg.substring(17, 18)) *
+      (Number(msg.substring(18, 21)) + Number(msg.substring(21, 23)) / 60),
+  });
+  ResultFormatter.altitude(result, Number(msg.substring(23, 28)));
+  ResultFormatter.unknown(result, msg.substring(28));
+  result.decoded = true;
+  result.decoder.decodeLevel = 'partial';
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H1_WRN.ts
+++ b/lib/plugins/escape_hatches/Label_H1_WRN.ts
@@ -1,0 +1,63 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_H1_WRN.
+ *
+ * Splits on '/WN'. The header before '/WN' becomes a chain of unknown
+ * items (skipping fields[0], the msg type). The 20 bytes after '/WN'
+ * carry datetime metadata (YYMMDDHHMMSS at offsets 0..12, reshuffled to
+ * DDMMYY for convertDateTimeToEpoch) plus a trailing 8-byte unknown
+ * block. The remainder of parts[1] is stored as the warning message
+ * body and surfaced as a custom 'warning' / 'WRN' formatted item.
+ */
+export function label_h1_wrn_parse(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const parts = message.text.split('/WN');
+
+  if (parts.length > 1) {
+    const fields = parts[0].split('/');
+    ResultFormatter.unknownArr(result, fields.slice(1), '/');
+
+    const data = parts[1].substring(0, 20);
+    const msg = parts[1].substring(20);
+    const datetime = data.substring(0, 12);
+    const date =
+      datetime.substring(4, 6) +
+      datetime.substring(2, 4) +
+      datetime.substring(0, 2);
+
+    ResultFormatter.unknown(result, data.substring(12), '/');
+    result.raw.message_timestamp = DateTimeUtils.convertDateTimeToEpoch(
+      datetime.substring(6),
+      date,
+    );
+    result.raw.warning_message = msg;
+    result.formatted.items.push({
+      type: 'warning',
+      code: 'WRN',
+      label: 'Warning Message',
+      value: String(result.raw.warning_message),
+    });
+    result.decoded = true;
+    result.decoder.decodeLevel = 'partial';
+  } else {
+    if (options.debug) {
+      console.log(`[${result.decoder.name}] Unknown message: ${message.text}`);
+    }
+    ResultFormatter.unknown(result, message.text);
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_H2_02E.ts
+++ b/lib/plugins/escape_hatches/Label_H2_02E.ts
@@ -1,0 +1,111 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+  Wind,
+} from '@airframes/ads-runtime-ts';
+import {
+  CoordinateUtils,
+  DateTimeUtils,
+  ResultFormatter,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_H2_02E.
+ *
+ * Space-split message must end with a 'Q' sentinel. The 45-char header
+ * encodes day (chars 3..5), departure ICAO (5..9), arrival ICAO (9..13),
+ * and a first weather record (13..). Each subsequent space-separated
+ * chunk must start with 'Q' followed by a 32-char weather record. Any
+ * chunk that doesn't parse cleanly is appended (space-joined) to
+ * remaining.text, downgrading the decode level from 'full' to 'partial'.
+ */
+export function label_h2_02e_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  const parts = message.text.split(' ');
+
+  if (parts[parts.length - 1] !== 'Q') {
+    result.remaining.text = message.text;
+    result.decoded = false;
+    result.decoder.decodeLevel = 'none';
+    return result;
+  }
+
+  const windData: Wind[] = [];
+  result.remaining.text = '';
+
+  const header = parts[0];
+  if (header.length === 45) {
+    ResultFormatter.day(result, parseInt(header.substring(3, 5), 10));
+    ResultFormatter.departureAirport(result, header.substring(5, 9));
+    ResultFormatter.arrivalAirport(result, header.substring(9, 13));
+    const firstWind = parseWeatherReport(header.substring(13));
+    if (firstWind) {
+      windData.push(firstWind);
+    } else {
+      result.remaining.text +=
+        (result.remaining.text ? ' ' : '') + header.substring(13);
+    }
+  }
+
+  for (let i = 1; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (part[0] !== 'Q') {
+      result.remaining.text +=
+        (result.remaining.text ? ' ' : '') + part;
+      continue;
+    }
+    const wind = parseWeatherReport(part.substring(1));
+    if (wind) {
+      windData.push(wind);
+    } else {
+      result.remaining.text +=
+        (result.remaining.text ? ' ' : '') + part;
+    }
+  }
+
+  ResultFormatter.windData(result, windData);
+  result.decoded = true;
+  result.decoder.decodeLevel =
+    result.remaining.text.length === 0 ? 'full' : 'partial';
+  return result;
+}
+
+function parseWeatherReport(text: string): Wind | null {
+  const posString = text.substring(0, 13);
+  const pos =
+    CoordinateUtils.decodeStringCoordinatesDecimalMinutes(posString);
+  if (text.length !== 32 || !pos) {
+    return null;
+  }
+  const tod = DateTimeUtils.convertHHMMSSToTod(text.substring(13, 17));
+  const flightLevel = parseInt(text.substring(17, 20), 10);
+  const tempSign = text[21] === 'M' ? -1 : 1;
+  const tempDegreesRaw = parseInt(text.substring(22, 25), 10);
+  const tempDegrees = tempSign * (tempDegreesRaw / 10);
+  const windDirection = parseInt(text.substring(25, 28), 10);
+  const windSpeed = parseInt(text.substring(28, 31), 10);
+  if (text[31] !== 'G') {
+    return null;
+  }
+  return {
+    waypoint: {
+      name: posString,
+      latitude: pos.latitude,
+      longitude: pos.longitude,
+      time: tod,
+    },
+    flightLevel,
+    windDirection,
+    windSpeed,
+    temperature: {
+      flightLevel,
+      degreesC: tempDegrees,
+    },
+  };
+}

--- a/lib/plugins/escape_hatches/Label_HX.ts
+++ b/lib/plugins/escape_hatches/Label_HX.ts
@@ -1,0 +1,60 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_HX (Undelivered Uplink Report).
+ *
+ * Space-split message dispatches on parts[2]:
+ *  - 'LOCATION': parts[3]/[4] are packed N/S/E/W coords
+ *    (e.g. "N4009.6" + "W07540.8"), decoded as deg + min/60 with sign
+ *    from the direction char. parts.slice(5) accumulated as unknown.
+ *  - '43': parts[3] is the departure airport; parts.slice(4) become
+ *    unknown.
+ *  - anything else: decoded=false, decodeLevel='none'.
+ */
+export function label_hx_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  const parts = message.text.split(' ');
+
+  result.decoded = true;
+  if (parts[2] === 'LOCATION') {
+    const latdir = parts[3].substring(0, 1);
+    const latdeg = Number(parts[3].substring(1, 3));
+    const latmin = Number(parts[3].substring(3, 7));
+    const londir = parts[4].substring(0, 1);
+    const londeg = Number(parts[4].substring(1, 4));
+    const lonmin = Number(parts[4].substring(4, 8));
+    const pos = {
+      latitude: (latdeg + latmin / 60) * (latdir === 'N' ? 1 : -1),
+      longitude: (londeg + lonmin / 60) * (londir === 'E' ? 1 : -1),
+    };
+    ResultFormatter.unknownArr(result, parts.slice(5), ' ');
+    ResultFormatter.position(result, pos);
+  } else if (parts[2] === '43') {
+    ResultFormatter.departureAirport(result, parts[3]);
+    ResultFormatter.unknownArr(result, parts.slice(4), ' ');
+  } else {
+    result.decoded = false;
+  }
+
+  if (result.decoded) {
+    if (!result.remaining.text) {
+      result.decoder.decodeLevel = 'full';
+    } else {
+      result.decoder.decodeLevel = 'partial';
+    }
+  } else {
+    result.decoder.decodeLevel = 'none';
+  }
+
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_MA.ts
+++ b/lib/plugins/escape_hatches/Label_MA.ts
@@ -1,0 +1,79 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { ResultFormatter } from '@airframes/ads-runtime-ts';
+import { MIAMCoreUtils } from '../../utils/miam';
+
+/**
+ * Whole-plugin parse hatch for Label_MA (MIAM core).
+ *
+ * Runs MIAMCoreUtils.parse on the raw text (ASCII85 + deflate + CRC +
+ * version-dependent PDU framing). When the inner ACARS PDU is present
+ * we emit label/sublabel/tail items, and if the PDU is CRC-OK +
+ * complete + carries text we recursively dispatch back through the
+ * MessageDecoder. Recursive results are merged into raw/items/remaining;
+ * a failed inner decode falls back to a plain text item + remaining.
+ */
+export function label_ma_dispatch(
+  plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  options: Options,
+): DecodeResult {
+  const miamResult = MIAMCoreUtils.parse(message.text);
+  if (
+    miamResult.decoded &&
+    miamResult.message.data &&
+    miamResult.message.data.acars
+  ) {
+    result.decoded = true;
+    ResultFormatter.label(result, miamResult.message.data.acars.label);
+    if (miamResult.message.data.acars.sublabel) {
+      ResultFormatter.sublabel(
+        result,
+        miamResult.message.data.acars.sublabel,
+      );
+    }
+    if (miamResult.message.data.acars.tail) {
+      ResultFormatter.tail(
+        result,
+        miamResult.message.data.acars.tail.replace('.', ''),
+      );
+    }
+
+    const messageText = miamResult.message.data.acars.text;
+    if (
+      miamResult.message.data.crcOk &&
+      miamResult.message.data.complete &&
+      messageText
+    ) {
+      result.decoder.decodeLevel = 'full';
+      const decoded = plugin.decoder.decode(
+        {
+          label: miamResult.message.data.acars.label,
+          sublabel: miamResult.message.data.acars.sublabel,
+          text: messageText,
+        },
+        options,
+      );
+
+      if (decoded.decoded) {
+        result.raw = { ...result.raw, ...decoded.raw };
+        result.formatted.items.push(...decoded.formatted.items);
+        result.remaining = decoded.remaining;
+      } else {
+        ResultFormatter.text(result, messageText);
+        result.remaining = { text: messageText };
+      }
+    } else if (messageText) {
+      result.decoder.decodeLevel = 'partial';
+      result.remaining = { text: messageText };
+    } else {
+      result.decoder.decodeLevel = 'partial';
+    }
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_QP.ts
+++ b/lib/plugins/escape_hatches/Label_QP.ts
@@ -1,0 +1,38 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_QP (OUT Report).
+ *
+ *   text[0:4]  -> departure ICAO
+ *   text[4:8]  -> arrival ICAO
+ *   text[8:12] -> OUT time (HHMM, internally padded to HHMMSS)
+ *   text[12:]  -> trailing unknown bytes
+ */
+export function label_qp_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  ResultFormatter.departureAirport(result, message.text.substring(0, 4));
+  ResultFormatter.arrivalAirport(result, message.text.substring(4, 8));
+  ResultFormatter.out(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(message.text.substring(8, 12)),
+  );
+  ResultFormatter.unknown(result, message.text.substring(12));
+
+  result.decoded = true;
+  if (!result.remaining.text) {
+    result.decoder.decodeLevel = 'full';
+  } else {
+    result.decoder.decodeLevel = 'partial';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_QQ.ts
+++ b/lib/plugins/escape_hatches/Label_QQ.ts
@@ -1,0 +1,75 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_QQ (OFF Report).
+ *
+ * Variant A: text[12:19] == '\r\n001FE' — long form with day, OFF time,
+ * packed NSDDMM.M/EWDDDMM.M coordinates, an unknown 3-char block, then
+ * optional groundspeed (when the unknown block != '---') or another
+ * unknown chunk. Tail unknown bytes follow.
+ *
+ * Variant B (fallback): short form with OFF time only, then trailing
+ * unknown bytes.
+ *
+ * Order of ResultFormatter.unknown calls matters because each one
+ * appends to remaining.text (which the groundspeed branch reads).
+ */
+export function label_qq_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  ResultFormatter.departureAirport(result, message.text.substring(0, 4));
+  ResultFormatter.arrivalAirport(result, message.text.substring(4, 8));
+
+  if (message.text.substring(12, 19) === '\r\n001FE') {
+    result.raw.day = message.text.substring(19, 21);
+    ResultFormatter.off(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(message.text.substring(21, 27)),
+    );
+    const latdir = message.text.substring(27, 28);
+    const latdeg = Number(message.text.substring(28, 30));
+    const latmin = Number(message.text.substring(30, 34));
+    const londir = message.text.substring(34, 35);
+    const londeg = Number(message.text.substring(35, 38));
+    const lonmin = Number(message.text.substring(38, 42));
+    const pos = {
+      latitude: (latdeg + latmin / 60) * (latdir === 'N' ? 1 : -1),
+      longitude: (londeg + lonmin / 60) * (londir === 'E' ? 1 : -1),
+    };
+    ResultFormatter.unknown(result, message.text.substring(42, 45));
+    ResultFormatter.position(result, pos);
+
+    if (result.remaining.text !== '---') {
+      ResultFormatter.groundspeed(
+        result,
+        Number(message.text.substring(45, 48)),
+      );
+    } else {
+      ResultFormatter.unknown(result, message.text.substring(45, 48));
+    }
+    ResultFormatter.unknown(result, message.text.substring(48));
+  } else {
+    ResultFormatter.off(
+      result,
+      DateTimeUtils.convertHHMMSSToTod(message.text.substring(8, 12) + '00'),
+    );
+    ResultFormatter.unknown(result, message.text.substring(12));
+  }
+
+  result.decoded = true;
+  if (!result.remaining.text) {
+    result.decoder.decodeLevel = 'full';
+  } else {
+    result.decoder.decodeLevel = 'partial';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_QR.ts
+++ b/lib/plugins/escape_hatches/Label_QR.ts
@@ -1,0 +1,34 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_QR (ON Report).
+ * Mirrors QP but emits ON time instead of OUT time.
+ */
+export function label_qr_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  ResultFormatter.departureAirport(result, message.text.substring(0, 4));
+  ResultFormatter.arrivalAirport(result, message.text.substring(4, 8));
+  ResultFormatter.on(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(message.text.substring(8, 12)),
+  );
+  ResultFormatter.unknown(result, message.text.substring(12));
+
+  result.decoded = true;
+  if (!result.remaining.text) {
+    result.decoder.decodeLevel = 'full';
+  } else {
+    result.decoder.decodeLevel = 'partial';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_QS.ts
+++ b/lib/plugins/escape_hatches/Label_QS.ts
@@ -1,0 +1,34 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+import { DateTimeUtils, ResultFormatter } from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_QS (IN Report).
+ * Mirrors QP but emits IN time instead of OUT time.
+ */
+export function label_qs_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  ResultFormatter.departureAirport(result, message.text.substring(0, 4));
+  ResultFormatter.arrivalAirport(result, message.text.substring(4, 8));
+  ResultFormatter.in(
+    result,
+    DateTimeUtils.convertHHMMSSToTod(message.text.substring(8, 12)),
+  );
+  ResultFormatter.unknown(result, message.text.substring(12));
+
+  result.decoded = true;
+  if (!result.remaining.text) {
+    result.decoder.decodeLevel = 'full';
+  } else {
+    result.decoder.decodeLevel = 'partial';
+  }
+  return result;
+}

--- a/lib/plugins/escape_hatches/Label_SQ.ts
+++ b/lib/plugins/escape_hatches/Label_SQ.ts
@@ -1,0 +1,136 @@
+import type {
+  DecodeResult,
+  DecoderPlugin,
+  Message,
+  Options,
+} from '@airframes/ads-runtime-ts';
+
+/**
+ * Whole-plugin parse hatch for Label_SQ (Ground Station Squitter).
+ *
+ * preamble = text[0:4]; version = Number(text[1:2]); network = text[3:4].
+ * For version 2 messages, a regex pulls out organization/IATA/ICAO/station
+ * number/coords/VDL frequency. Network is mapped A→ARINC, S→SITA,
+ * else Unknown.
+ *
+ * formatted.items is built from scratch (replacing the empty array
+ * initialized by the plugin's initResult) with NETT and VER, then any
+ * optional fields (GNDSTN, IATA, ICAO, COORD, APT, VDLFRQ) appended only
+ * when their source value is present.
+ */
+export function label_sq_dispatch(
+  _plugin: DecoderPlugin,
+  message: Message,
+  result: DecodeResult,
+  _options: Options,
+): DecodeResult {
+  result.raw.preamble = message.text.substring(0, 4);
+  result.raw.version = Number(message.text.substring(1, 2));
+  result.raw.network = message.text.substring(3, 4);
+
+  if (result.raw.version === 2) {
+    const regex =
+      /0(\d)X(?<org>\w)(?<iata>\w\w\w)(?<icao>\w\w\w\w)(?<station>\d)(?<lat>\d+)(?<latd>[NS])(?<lng>\d+)(?<lngd>[EW])V(?<vfreq>\d+)\/.*/;
+    const match = message.text.match(regex);
+
+    if (match?.groups && match.length >= 8) {
+      result.raw.groundStation = {
+        number: match.groups.station,
+        iataCode: match.groups.iata,
+        icaoCode: match.groups.icao,
+        coordinates: {
+          latitude:
+            (Number(match.groups.lat) / 100) *
+            (match.groups.latd === 'S' ? -1 : 1),
+          longitude:
+            (Number(match.groups.lng) / 100) *
+            (match.groups.lngd === 'W' ? -1 : 1),
+        },
+      };
+      result.raw.vdlFrequency = Number(match.groups.vfreq) / 1000.0;
+    }
+  }
+
+  let formattedNetwork = 'Unknown';
+  if (result.raw.network === 'A') {
+    formattedNetwork = 'ARINC';
+  } else if (result.raw.network === 'S') {
+    formattedNetwork = 'SITA';
+  }
+  result.formatted.items = [
+    {
+      type: 'network',
+      code: 'NETT',
+      label: 'Network',
+      value: formattedNetwork,
+    },
+    {
+      type: 'version',
+      code: 'VER',
+      label: 'Version',
+      value: String(result.raw.version),
+    },
+  ];
+
+  if (result.raw.groundStation) {
+    const gs = result.raw.groundStation as {
+      number?: string;
+      iataCode?: string;
+      icaoCode?: string;
+      coordinates: { latitude?: number; longitude?: number };
+      airport?: { name: string; icao: string; location: string };
+    };
+    if (gs.icaoCode && gs.number) {
+      result.formatted.items.push({
+        type: 'ground_station',
+        code: 'GNDSTN',
+        label: 'Ground Station',
+        value: `${gs.icaoCode}${gs.number}`,
+      });
+    }
+    if (gs.iataCode) {
+      result.formatted.items.push({
+        type: 'iataCode',
+        code: 'IATA',
+        label: 'IATA',
+        value: gs.iataCode,
+      });
+    }
+    if (gs.icaoCode) {
+      result.formatted.items.push({
+        type: 'icaoCode',
+        code: 'ICAO',
+        label: 'ICAO',
+        value: gs.icaoCode,
+      });
+    }
+    if (gs.coordinates.latitude) {
+      result.formatted.items.push({
+        type: 'coordinates',
+        code: 'COORD',
+        label: 'Ground Station Location',
+        value: `${gs.coordinates.latitude}, ${gs.coordinates.longitude}`,
+      });
+    }
+    if (gs.airport) {
+      result.formatted.items.push({
+        type: 'airport',
+        code: 'APT',
+        label: 'Airport',
+        value: `${gs.airport.name} (${gs.airport.icao}) in ${gs.airport.location}`,
+      });
+    }
+  }
+
+  if (result.raw.vdlFrequency) {
+    result.formatted.items.push({
+      type: 'vdlFrequency',
+      code: 'VDLFRQ',
+      label: 'VDL Frequency',
+      value: `${result.raw.vdlFrequency} MHz`,
+    });
+  }
+  result.decoded = true;
+  result.decoder.decodeLevel = 'full';
+  return result;
+}

--- a/lib/plugins/escape_hatches/index.ts
+++ b/lib/plugins/escape_hatches/index.ts
@@ -27,6 +27,7 @@ export * from "./Label_2P_FM3";
 export * from "./Label_2P_FM4";
 export * from "./Label_2P_FM5";
 export * from "./Label_30_Slash_EA";
+export * from "./Label_44_POS";
 export * from "./Label_44_Slash";
 export * from "./Label_4A_01";
 export * from "./Label_4A_DIS";

--- a/lib/plugins/escape_hatches/index.ts
+++ b/lib/plugins/escape_hatches/index.ts
@@ -1,0 +1,13 @@
+// Per-plugin escape-hatch functions referenced from generated plugins
+// (via `import * as hatches from '../escape_hatches'`). As Stage 2.5
+// progresses, escape hatches for each plugin are added here as named
+// exports.
+//
+// See docs/ESCAPE_HATCHES.md in airframes-decoder for the contract:
+//   parse-level:    (plugin, message, result, options) => DecodeResult
+//   field-level:    (value, args) => unknown
+//   formatter-level:(result) => void
+//
+// Empty for now — the pilot swap (Label_10_POS) doesn't reference any
+// hatches; future plugins will populate this module.
+export {};

--- a/lib/plugins/escape_hatches/index.ts
+++ b/lib/plugins/escape_hatches/index.ts
@@ -1,13 +1,62 @@
-// Per-plugin escape-hatch functions referenced from generated plugins
-// (via `import * as hatches from '../escape_hatches'`). As Stage 2.5
-// progresses, escape hatches for each plugin are added here as named
-// exports.
-//
-// See docs/ESCAPE_HATCHES.md in airframes-decoder for the contract:
-//   parse-level:    (plugin, message, result, options) => DecodeResult
-//   field-level:    (value, args) => unknown
-//   formatter-level:(result) => void
-//
-// Empty for now — the pilot swap (Label_10_POS) doesn't reference any
-// hatches; future plugins will populate this module.
-export {};
+export * from "./ARINC_702";
+export * from "./CBand";
+export * from "./Label_10_LDR";
+export * from "./Label_10_Slash";
+export * from "./Label_12_N_Space";
+export * from "./Label_12_POS";
+export * from "./Label_13Through18_Slash";
+export * from "./Label_15_FST";
+export * from "./Label_15";
+export * from "./Label_16_AUTPOS";
+export * from "./Label_16_Honeywell";
+export * from "./Label_16_N_Space";
+export * from "./Label_16_POSA1";
+export * from "./Label_16_TOD";
+export * from "./Label_1L_070";
+export * from "./Label_1L_3Line";
+export * from "./Label_1L_660";
+export * from "./Label_1L_Slash";
+export * from "./Label_1M_Slash";
+export * from "./Label_20_CFB01";
+export * from "./Label_20_POS";
+export * from "./Label_21_POS";
+export * from "./Label_22_OFF";
+export * from "./Label_22_POS";
+export * from "./Label_24_Slash";
+export * from "./Label_2P_FM3";
+export * from "./Label_2P_FM4";
+export * from "./Label_2P_FM5";
+export * from "./Label_30_Slash_EA";
+export * from "./Label_44_Slash";
+export * from "./Label_4A_01";
+export * from "./Label_4A_DIS";
+export * from "./Label_4A_DOOR";
+export * from "./Label_4A_Slash_01";
+export * from "./Label_4A";
+export * from "./Label_4N";
+export * from "./Label_4T_AGFSR";
+export * from "./Label_4T_ETA";
+export * from "./Label_58";
+export * from "./Label_5Z_Slash";
+export * from "./Label_80";
+export * from "./Label_83";
+export * from "./Label_8E";
+export * from "./Label_B6_Forwardslash";
+export * from "./Label_ColonComma";
+export * from "./Label_H1_ATIS";
+export * from "./Label_H1_EZF";
+export * from "./Label_H1_FLR";
+export * from "./Label_H1_M_POS";
+export * from "./Label_H1_OFP";
+export * from "./Label_H1_OHMA";
+export * from "./Label_H1_Paren";
+export * from "./Label_H1_StarPOS";
+export * from "./Label_H1_WRN";
+export * from "./Label_H2_02E";
+export * from "./Label_HX";
+export * from "./Label_MA";
+export * from "./Label_QP";
+export * from "./Label_QQ";
+export * from "./Label_QR";
+export * from "./Label_QS";
+export * from "./Label_SQ";

--- a/lib/plugins/generated/ARINC_702.ts
+++ b/lib/plugins/generated/ARINC_702.ts
@@ -18,7 +18,7 @@ export class ARINC_702 extends DecoderPlugin {
   }
 
   decode(message: Message, options: Options = {}): DecodeResult {
-    const result = this.initResult(message, "ARINC 702 Message");
+    const result = this.initResult(message, "Unknown");
 
     return hatches.arinc_702_dispatch(this, message, result, options);
   }

--- a/lib/plugins/generated/ARINC_702.ts
+++ b/lib/plugins/generated/ARINC_702.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/wildcards/arinc_702.yaml. Do not edit.
+// Plugin: ARINC_702
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/ARINC_702.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class ARINC_702 extends DecoderPlugin {
+  name = "arinc-702";
+
+  qualifiers() {
+    return {
+      labels: ["*"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ARINC 702 Message");
+
+    return hatches.arinc_702_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/CBand.ts
+++ b/lib/plugins/generated/CBand.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/wildcards/cband.yaml. Do not edit.
+// Plugin: CBand
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class CBand extends DecoderPlugin {
+  name = "cband";
+
+  qualifiers() {
+    return {
+      labels: ["*"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "C-Band Message");
+
+    return hatches.cband_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/CBand.ts
+++ b/lib/plugins/generated/CBand.ts
@@ -8,7 +8,7 @@ import * as helpers from "@airframes/ads-runtime-ts/helpers";
 import * as hatches from "../escape_hatches";
 
 export class CBand extends DecoderPlugin {
-  name = "cband";
+  name = "c-band";
 
   qualifiers() {
     return {

--- a/lib/plugins/generated/Label_10_LDR.ts
+++ b/lib/plugins/generated/Label_10_LDR.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/10/LDR.yaml. Do not edit.
+// Plugin: Label_10_LDR
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_10_LDR extends DecoderPlugin {
+  name = "label-10-ldr";
+
+  qualifiers() {
+    return {
+      labels: ["10"],
+      preambles: ["LDR"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_10_ldr_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_10_POS.ts
+++ b/lib/plugins/generated/Label_10_POS.ts
@@ -1,0 +1,40 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/10/POS.yaml. Do not edit.
+// Plugin: Label_10_POS
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/10/POS.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_10_POS extends DecoderPlugin {
+  name = "label-10-pos";
+
+  qualifiers() {
+    return {
+      labels: ["10"],
+      preambles: ["POS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    const parts = message.text.split(",");
+    if (parts.length !== 12) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const latitude = helpers.coordinate(parts[1], {"style":"single_axis","axis":"latitude","prefix_chars":["N","S"],"digits":5,"divisor":100});
+    result.raw.latitude = latitude;
+    const longitude = helpers.coordinate(parts[2], {"style":"single_axis","axis":"longitude","prefix_chars":["E","W"],"digits":5,"divisor":100});
+    result.raw.longitude = longitude;
+    const altitude = helpers.integer(parts[7]);
+    result.raw.altitude = altitude;
+    ResultFormatter.position(result, { latitude: latitude, longitude: longitude });
+    ResultFormatter.altitude(result, altitude);
+    ResultFormatter.unknownArr(result, [parts[0], parts[3], parts[4], parts[5], parts[6], parts[8], parts[9], parts[10], parts[11]]);
+    this.setDecodeLevel(result, true, 'partial');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_10_POS.ts
+++ b/lib/plugins/generated/Label_10_POS.ts
@@ -26,11 +26,8 @@ export class Label_10_POS extends DecoderPlugin {
       return this.failUnknown(result, message.text, options);
     }
     const latitude = helpers.coordinate(parts[1], {"style":"single_axis","axis":"latitude","prefix_chars":["N","S"],"digits":5,"divisor":100});
-    result.raw.latitude = latitude;
     const longitude = helpers.coordinate(parts[2], {"style":"single_axis","axis":"longitude","prefix_chars":["E","W"],"digits":5,"divisor":100});
-    result.raw.longitude = longitude;
     const altitude = helpers.integer(parts[7]);
-    result.raw.altitude = altitude;
     ResultFormatter.position(result, { latitude: latitude, longitude: longitude });
     ResultFormatter.altitude(result, altitude);
     ResultFormatter.unknownArr(result, [parts[0], parts[3], parts[4], parts[5], parts[6], parts[8], parts[9], parts[10], parts[11]]);

--- a/lib/plugins/generated/Label_10_Slash.ts
+++ b/lib/plugins/generated/Label_10_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/10/Slash.yaml. Do not edit.
+// Plugin: Label_10_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_10_Slash extends DecoderPlugin {
+  name = "label-10-slash";
+
+  qualifiers() {
+    return {
+      labels: ["10"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_10_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_12_N_Space.ts
+++ b/lib/plugins/generated/Label_12_N_Space.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/12/N_Space.yaml. Do not edit.
+// Plugin: Label_12_N_Space
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_12_N_Space extends DecoderPlugin {
+  name = "label-12-n-space";
+
+  qualifiers() {
+    return {
+      labels: ["12"],
+      preambles: ["N ","S "],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_12_n_space_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_12_POS.ts
+++ b/lib/plugins/generated/Label_12_POS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/12/POS.yaml. Do not edit.
+// Plugin: Label_12_POS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_12_POS extends DecoderPlugin {
+  name = "label-12-pos";
+
+  qualifiers() {
+    return {
+      labels: ["12"],
+      preambles: ["POS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_12_pos_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_13Through18_Slash.ts
+++ b/lib/plugins/generated/Label_13Through18_Slash.ts
@@ -8,7 +8,7 @@ import * as helpers from "@airframes/ads-runtime-ts/helpers";
 import * as hatches from "../escape_hatches";
 
 export class Label_13Through18_Slash extends DecoderPlugin {
-  name = "label-13through18-slash";
+  name = "label-13-through18-slash";
 
   qualifiers() {
     return {

--- a/lib/plugins/generated/Label_13Through18_Slash.ts
+++ b/lib/plugins/generated/Label_13Through18_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/wildcards/label_13_18_slash.yaml. Do not edit.
+// Plugin: Label_13Through18_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_13Through18_Slash extends DecoderPlugin {
+  name = "label-13through18-slash";
+
+  qualifiers() {
+    return {
+      labels: ["13","14","15","16","17","18"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "OOOI Report");
+
+    return hatches.label_13_18_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_15.ts
+++ b/lib/plugins/generated/Label_15.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/15/Paren2.yaml. Do not edit.
+// Plugin: Label_15
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_15 extends DecoderPlugin {
+  name = "label-15";
+
+  qualifiers() {
+    return {
+      labels: ["15"],
+      preambles: ["(2"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_15_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_15_FST.ts
+++ b/lib/plugins/generated/Label_15_FST.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/15/FST.yaml. Do not edit.
+// Plugin: Label_15_FST
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_15_FST extends DecoderPlugin {
+  name = "label-15-fst";
+
+  qualifiers() {
+    return {
+      labels: ["15"],
+      preambles: ["FST01"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_15_fst_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_16_AUTPOS.ts
+++ b/lib/plugins/generated/Label_16_AUTPOS.ts
@@ -18,7 +18,7 @@ export class Label_16_AUTPOS extends DecoderPlugin {
   }
 
   decode(message: Message, options: Options = {}): DecodeResult {
-    const result = this.initResult(message, "Position Report");
+    const result = this.initResult(message, "Unknown");
 
     return hatches.label_16_autpos_decode(this, message, result, options);
   }

--- a/lib/plugins/generated/Label_16_AUTPOS.ts
+++ b/lib/plugins/generated/Label_16_AUTPOS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/16/AUTPOS.yaml. Do not edit.
+// Plugin: Label_16_AUTPOS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_16_AUTPOS extends DecoderPlugin {
+  name = "label-16-autpos";
+
+  qualifiers() {
+    return {
+      labels: ["16"],
+      preambles: [""],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_16_autpos_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_16_Honeywell.ts
+++ b/lib/plugins/generated/Label_16_Honeywell.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/16/Honeywell.yaml. Do not edit.
+// Plugin: Label_16_Honeywell
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_16_Honeywell extends DecoderPlugin {
+  name = "label-16-honeywell";
+
+  qualifiers() {
+    return {
+      labels: ["16"],
+      preambles: ["(2"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_16_honeywell_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_16_N_Space.ts
+++ b/lib/plugins/generated/Label_16_N_Space.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/16/N_Space.yaml. Do not edit.
+// Plugin: Label_16_N_Space
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_16_N_Space extends DecoderPlugin {
+  name = "label-16-n-space";
+
+  qualifiers() {
+    return {
+      labels: ["16"],
+      preambles: ["N ","S "],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_16_n_space_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_16_POSA1.ts
+++ b/lib/plugins/generated/Label_16_POSA1.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/16/POSA1.yaml. Do not edit.
+// Plugin: Label_16_POSA1
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_16_POSA1 extends DecoderPlugin {
+  name = "label-16-posa1";
+
+  qualifiers() {
+    return {
+      labels: ["16"],
+      preambles: ["POSA1"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_16_posa1_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_16_TOD.ts
+++ b/lib/plugins/generated/Label_16_TOD.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/16/TOD.yaml. Do not edit.
+// Plugin: Label_16_TOD
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_16_TOD extends DecoderPlugin {
+  name = "label-16-tod";
+
+  qualifiers() {
+    return {
+      labels: ["16"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_16_tod_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_1L_070.ts
+++ b/lib/plugins/generated/Label_1L_070.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/1L/070.yaml. Do not edit.
+// Plugin: Label_1L_070
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_1L_070 extends DecoderPlugin {
+  name = "label-1l-070";
+
+  qualifiers() {
+    return {
+      labels: ["1L"],
+      preambles: ["000000070"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_1l_070_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_1L_3Line.ts
+++ b/lib/plugins/generated/Label_1L_3Line.ts
@@ -8,7 +8,7 @@ import * as helpers from "@airframes/ads-runtime-ts/helpers";
 import * as hatches from "../escape_hatches";
 
 export class Label_1L_3Line extends DecoderPlugin {
-  name = "label-1l-3line";
+  name = "label-1l-3-line";
 
   qualifiers() {
     return {

--- a/lib/plugins/generated/Label_1L_3Line.ts
+++ b/lib/plugins/generated/Label_1L_3Line.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/1L/3-line.yaml. Do not edit.
+// Plugin: Label_1L_3Line
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_1L_3Line extends DecoderPlugin {
+  name = "label-1l-3line";
+
+  qualifiers() {
+    return {
+      labels: ["1L"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_1l_3line_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_1L_660.ts
+++ b/lib/plugins/generated/Label_1L_660.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/1L/660.yaml. Do not edit.
+// Plugin: Label_1L_660
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_1L_660 extends DecoderPlugin {
+  name = "label-1l-660";
+
+  qualifiers() {
+    return {
+      labels: ["1L"],
+      preambles: ["000000660"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_1l_660_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_1L_Slash.ts
+++ b/lib/plugins/generated/Label_1L_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/1L/Slash.yaml. Do not edit.
+// Plugin: Label_1L_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_1L_Slash extends DecoderPlugin {
+  name = "label-1l-slash";
+
+  qualifiers() {
+    return {
+      labels: ["1L"],
+      preambles: ["+","-"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_1l_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_1M_Slash.ts
+++ b/lib/plugins/generated/Label_1M_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/1M/Slash.yaml. Do not edit.
+// Plugin: Label_1M_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_1M_Slash extends DecoderPlugin {
+  name = "label-1m-slash";
+
+  qualifiers() {
+    return {
+      labels: ["1M"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ETA Report");
+
+    return hatches.label_1m_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_20_CFB01.ts
+++ b/lib/plugins/generated/Label_20_CFB01.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/20/CFB01.yaml. Do not edit.
+// Plugin: Label_20_CFB01
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_20_CFB01 extends DecoderPlugin {
+  name = "label-20-cfb01";
+
+  qualifiers() {
+    return {
+      labels: ["20"],
+      preambles: ["#CFB.01"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Crew Flight Bag Message");
+
+    return hatches.label_20_cfb01_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_20_POS.ts
+++ b/lib/plugins/generated/Label_20_POS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/20/POS.yaml. Do not edit.
+// Plugin: Label_20_POS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_20_POS extends DecoderPlugin {
+  name = "label-20-pos";
+
+  qualifiers() {
+    return {
+      labels: ["20"],
+      preambles: ["POS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_20_pos_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_21_POS.ts
+++ b/lib/plugins/generated/Label_21_POS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/21/POS.yaml. Do not edit.
+// Plugin: Label_21_POS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_21_POS extends DecoderPlugin {
+  name = "label-21-pos";
+
+  qualifiers() {
+    return {
+      labels: ["21"],
+      preambles: ["POS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_21_pos_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_22_OFF.ts
+++ b/lib/plugins/generated/Label_22_OFF.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/22/OFF.yaml. Do not edit.
+// Plugin: Label_22_OFF
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_22_OFF extends DecoderPlugin {
+  name = "label-22-off";
+
+  qualifiers() {
+    return {
+      labels: ["22"],
+      preambles: ["OFF"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Takeoff Report");
+
+    return hatches.label_22_off_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_22_POS.ts
+++ b/lib/plugins/generated/Label_22_POS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/22/POS.yaml. Do not edit.
+// Plugin: Label_22_POS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_22_POS extends DecoderPlugin {
+  name = "label-22-pos";
+
+  qualifiers() {
+    return {
+      labels: ["22"],
+      preambles: ["N","S"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_22_pos_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_24_Slash.ts
+++ b/lib/plugins/generated/Label_24_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/24/Slash.yaml. Do not edit.
+// Plugin: Label_24_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_24_Slash extends DecoderPlugin {
+  name = "label-24-slash";
+
+  qualifiers() {
+    return {
+      labels: ["24"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_24_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_2P_FM3.ts
+++ b/lib/plugins/generated/Label_2P_FM3.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/2P/FM3.yaml. Do not edit.
+// Plugin: Label_2P_FM3
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_2P_FM3 extends DecoderPlugin {
+  name = "label-2p-fm3";
+
+  qualifiers() {
+    return {
+      labels: ["2P"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Flight Report");
+
+    return hatches.label_2p_fm3_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_2P_FM4.ts
+++ b/lib/plugins/generated/Label_2P_FM4.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/2P/FM4.yaml. Do not edit.
+// Plugin: Label_2P_FM4
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_2P_FM4 extends DecoderPlugin {
+  name = "label-2p-fm4";
+
+  qualifiers() {
+    return {
+      labels: ["2P"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Flight Report");
+
+    return hatches.label_2p_fm4_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_2P_FM5.ts
+++ b/lib/plugins/generated/Label_2P_FM5.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/2P/FM5.yaml. Do not edit.
+// Plugin: Label_2P_FM5
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_2P_FM5 extends DecoderPlugin {
+  name = "label-2p-fm5";
+
+  qualifiers() {
+    return {
+      labels: ["2P"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Flight Report");
+
+    return hatches.label_2p_fm5_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_30_Slash_EA.ts
+++ b/lib/plugins/generated/Label_30_Slash_EA.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/30/Slash_EA.yaml. Do not edit.
+// Plugin: Label_30_Slash_EA
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_30_Slash_EA extends DecoderPlugin {
+  name = "label-30-slash-ea";
+
+  qualifiers() {
+    return {
+      labels: ["30"],
+      preambles: ["/EA"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ETA Report");
+
+    return hatches.label_30_slash_ea_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_44_ETA.ts
+++ b/lib/plugins/generated/Label_44_ETA.ts
@@ -25,24 +25,15 @@ export class Label_44_ETA extends DecoderPlugin {
       return this.failUnknown(result, message.text, options);
     }
     const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
-    result.raw.position = position;
     const altitude = helpers.integer(data[2], {"multiplier":100});
-    result.raw.altitude = altitude;
     const departure_icao = helpers.airport(data[3]);
-    result.raw.departure_icao = departure_icao;
     const arrival_icao = helpers.airport(data[4]);
-    result.raw.arrival_icao = arrival_icao;
     const month = helpers.integer(data[5], {"substring_start":0,"substring_length":2});
-    result.raw.month = month;
     const day = helpers.integer(data[5], {"substring_start":2,"substring_length":2});
-    result.raw.day = day;
     const timestamp = helpers.timestampHhmmss(data[6]);
-    result.raw.timestamp = timestamp;
     const eta_time = helpers.timestampHhmmss(data[7]);
-    result.raw.eta_time = eta_time;
     if (!(["---.-"].includes(data[8]))) {
       const fuel_remaining = helpers.float(data[8]);
-      result.raw.fuel_remaining = fuel_remaining;
     }
     ResultFormatter.position(result, position);
     ResultFormatter.altitude(result, altitude);

--- a/lib/plugins/generated/Label_44_ETA.ts
+++ b/lib/plugins/generated/Label_44_ETA.ts
@@ -1,0 +1,59 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/ETA.yaml. Do not edit.
+// Plugin: Label_44_ETA
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_ETA extends DecoderPlugin {
+  name = "label-44-eta";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: ["00ETA01","00ETA02","00ETA03","ETA01","ETA02","ETA03"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ETA Report");
+
+    const data = message.text.split(",");
+    if (data.length < 9) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
+    result.raw.position = position;
+    const altitude = helpers.integer(data[2], {"multiplier":100});
+    result.raw.altitude = altitude;
+    const departure_icao = helpers.airport(data[3]);
+    result.raw.departure_icao = departure_icao;
+    const arrival_icao = helpers.airport(data[4]);
+    result.raw.arrival_icao = arrival_icao;
+    const month = helpers.integer(data[5], {"substring_start":0,"substring_length":2});
+    result.raw.month = month;
+    const day = helpers.integer(data[5], {"substring_start":2,"substring_length":2});
+    result.raw.day = day;
+    const timestamp = helpers.timestampHhmmss(data[6]);
+    result.raw.timestamp = timestamp;
+    const eta_time = helpers.timestampHhmmss(data[7]);
+    result.raw.eta_time = eta_time;
+    if (!(["---.-"].includes(data[8]))) {
+      const fuel_remaining = helpers.float(data[8]);
+      result.raw.fuel_remaining = fuel_remaining;
+    }
+    ResultFormatter.position(result, position);
+    ResultFormatter.altitude(result, altitude);
+    ResultFormatter.departureAirport(result, departure_icao);
+    ResultFormatter.arrivalAirport(result, arrival_icao);
+    ResultFormatter.timestamp(result, month);
+    ResultFormatter.timestamp(result, day);
+    ResultFormatter.timestamp(result, timestamp);
+    ResultFormatter.timestamp(result, eta_time);
+    ResultFormatter.fuel(result, fuel_remaining);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_44_ETA.ts
+++ b/lib/plugins/generated/Label_44_ETA.ts
@@ -32,8 +32,9 @@ export class Label_44_ETA extends DecoderPlugin {
     const day = helpers.integer(data[5], {"substring_start":2,"substring_length":2});
     const timestamp = helpers.timestampHhmmss(data[6]);
     const eta_time = helpers.timestampHhmmss(data[7]);
+    let fuel_remaining;
     if (!(["---.-"].includes(data[8]))) {
-      const fuel_remaining = helpers.float(data[8]);
+      fuel_remaining = helpers.float(data[8]);
     }
     ResultFormatter.position(result, position);
     ResultFormatter.altitude(result, altitude);
@@ -43,7 +44,7 @@ export class Label_44_ETA extends DecoderPlugin {
     ResultFormatter.timestamp(result, day);
     ResultFormatter.timestamp(result, timestamp);
     ResultFormatter.timestamp(result, eta_time);
-    ResultFormatter.fuel(result, fuel_remaining);
+    ResultFormatter.currentFuel(result, fuel_remaining);
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_ETA.ts
+++ b/lib/plugins/generated/Label_44_ETA.ts
@@ -40,11 +40,14 @@ export class Label_44_ETA extends DecoderPlugin {
     ResultFormatter.altitude(result, altitude);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
-    ResultFormatter.timestamp(result, month);
-    ResultFormatter.timestamp(result, day);
+    ResultFormatter.month(result, month);
+    ResultFormatter.day(result, day);
     ResultFormatter.timestamp(result, timestamp);
-    ResultFormatter.timestamp(result, eta_time);
-    ResultFormatter.currentFuel(result, fuel_remaining);
+    ResultFormatter.eta(result, eta_time);
+    ResultFormatter.remainingFuel(result, fuel_remaining);
+    if (data.length > 9) {
+      ResultFormatter.unknownArr(result, data.slice(9));
+    }
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_IN.ts
+++ b/lib/plugins/generated/Label_44_IN.ts
@@ -37,10 +37,13 @@ export class Label_44_IN extends DecoderPlugin {
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
-    ResultFormatter.timestamp(result, month);
-    ResultFormatter.timestamp(result, day);
-    ResultFormatter.timestamp(result, in_time);
-    ResultFormatter.currentFuel(result, fuel_remaining);
+    ResultFormatter.month(result, month);
+    ResultFormatter.day(result, day);
+    ResultFormatter.in(result, in_time);
+    ResultFormatter.remainingFuel(result, fuel_remaining);
+    if (data.length > 7) {
+      ResultFormatter.unknownArr(result, data.slice(7));
+    }
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_IN.ts
+++ b/lib/plugins/generated/Label_44_IN.ts
@@ -30,8 +30,9 @@ export class Label_44_IN extends DecoderPlugin {
     const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
     const in_time = helpers.timestampHhmmss(data[5]);
+    let fuel_remaining;
     if (!(["---.-"].includes(data[6]))) {
-      const fuel_remaining = helpers.float(data[6]);
+      fuel_remaining = helpers.float(data[6]);
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
@@ -39,7 +40,7 @@ export class Label_44_IN extends DecoderPlugin {
     ResultFormatter.timestamp(result, month);
     ResultFormatter.timestamp(result, day);
     ResultFormatter.timestamp(result, in_time);
-    ResultFormatter.fuel(result, fuel_remaining);
+    ResultFormatter.currentFuel(result, fuel_remaining);
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_IN.ts
+++ b/lib/plugins/generated/Label_44_IN.ts
@@ -25,20 +25,13 @@ export class Label_44_IN extends DecoderPlugin {
       return this.failUnknown(result, message.text, options);
     }
     const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
-    result.raw.position = position;
     const departure_icao = helpers.airport(data[2]);
-    result.raw.departure_icao = departure_icao;
     const arrival_icao = helpers.airport(data[3]);
-    result.raw.arrival_icao = arrival_icao;
     const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
-    result.raw.month = month;
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
-    result.raw.day = day;
     const in_time = helpers.timestampHhmmss(data[5]);
-    result.raw.in_time = in_time;
     if (!(["---.-"].includes(data[6]))) {
       const fuel_remaining = helpers.float(data[6]);
-      result.raw.fuel_remaining = fuel_remaining;
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);

--- a/lib/plugins/generated/Label_44_IN.ts
+++ b/lib/plugins/generated/Label_44_IN.ts
@@ -1,0 +1,53 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/IN.yaml. Do not edit.
+// Plugin: Label_44_IN
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_IN extends DecoderPlugin {
+  name = "label-44-in";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: ["00IN01","00IN02","00IN03","IN01","IN02","IN03"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "In Gate Report");
+
+    const data = message.text.split(",");
+    if (data.length < 7) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
+    result.raw.position = position;
+    const departure_icao = helpers.airport(data[2]);
+    result.raw.departure_icao = departure_icao;
+    const arrival_icao = helpers.airport(data[3]);
+    result.raw.arrival_icao = arrival_icao;
+    const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
+    result.raw.month = month;
+    const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
+    result.raw.day = day;
+    const in_time = helpers.timestampHhmmss(data[5]);
+    result.raw.in_time = in_time;
+    if (!(["---.-"].includes(data[6]))) {
+      const fuel_remaining = helpers.float(data[6]);
+      result.raw.fuel_remaining = fuel_remaining;
+    }
+    ResultFormatter.position(result, position);
+    ResultFormatter.departureAirport(result, departure_icao);
+    ResultFormatter.arrivalAirport(result, arrival_icao);
+    ResultFormatter.timestamp(result, month);
+    ResultFormatter.timestamp(result, day);
+    ResultFormatter.timestamp(result, in_time);
+    ResultFormatter.fuel(result, fuel_remaining);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_44_OFF.ts
+++ b/lib/plugins/generated/Label_44_OFF.ts
@@ -25,22 +25,14 @@ export class Label_44_OFF extends DecoderPlugin {
       return this.failUnknown(result, message.text, options);
     }
     const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
-    result.raw.position = position;
     const departure_icao = helpers.airport(data[2]);
-    result.raw.departure_icao = departure_icao;
     const arrival_icao = helpers.airport(data[3]);
-    result.raw.arrival_icao = arrival_icao;
     const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
-    result.raw.month = month;
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
-    result.raw.day = day;
     const off_time = helpers.timestampHhmmss(data[5]);
-    result.raw.off_time = off_time;
     const eta_time = helpers.timestampHhmmss(data[6]);
-    result.raw.eta_time = eta_time;
     if (!(["---.-"].includes(data[7]))) {
       const fuel_remaining = helpers.float(data[7]);
-      result.raw.fuel_remaining = fuel_remaining;
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);

--- a/lib/plugins/generated/Label_44_OFF.ts
+++ b/lib/plugins/generated/Label_44_OFF.ts
@@ -31,8 +31,9 @@ export class Label_44_OFF extends DecoderPlugin {
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
     const off_time = helpers.timestampHhmmss(data[5]);
     const eta_time = helpers.timestampHhmmss(data[6]);
+    let fuel_remaining;
     if (!(["---.-"].includes(data[7]))) {
-      const fuel_remaining = helpers.float(data[7]);
+      fuel_remaining = helpers.float(data[7]);
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
@@ -41,7 +42,7 @@ export class Label_44_OFF extends DecoderPlugin {
     ResultFormatter.timestamp(result, day);
     ResultFormatter.timestamp(result, off_time);
     ResultFormatter.timestamp(result, eta_time);
-    ResultFormatter.fuel(result, fuel_remaining);
+    ResultFormatter.currentFuel(result, fuel_remaining);
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_OFF.ts
+++ b/lib/plugins/generated/Label_44_OFF.ts
@@ -1,0 +1,56 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/OFF.yaml. Do not edit.
+// Plugin: Label_44_OFF
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_OFF extends DecoderPlugin {
+  name = "label-44-off";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: ["00OFF01","00OFF02","00OFF03","OFF01","OFF02","OFF03"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Off Runway Report");
+
+    const data = message.text.split(",");
+    if (data.length < 8) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
+    result.raw.position = position;
+    const departure_icao = helpers.airport(data[2]);
+    result.raw.departure_icao = departure_icao;
+    const arrival_icao = helpers.airport(data[3]);
+    result.raw.arrival_icao = arrival_icao;
+    const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
+    result.raw.month = month;
+    const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
+    result.raw.day = day;
+    const off_time = helpers.timestampHhmmss(data[5]);
+    result.raw.off_time = off_time;
+    const eta_time = helpers.timestampHhmmss(data[6]);
+    result.raw.eta_time = eta_time;
+    if (!(["---.-"].includes(data[7]))) {
+      const fuel_remaining = helpers.float(data[7]);
+      result.raw.fuel_remaining = fuel_remaining;
+    }
+    ResultFormatter.position(result, position);
+    ResultFormatter.departureAirport(result, departure_icao);
+    ResultFormatter.arrivalAirport(result, arrival_icao);
+    ResultFormatter.timestamp(result, month);
+    ResultFormatter.timestamp(result, day);
+    ResultFormatter.timestamp(result, off_time);
+    ResultFormatter.timestamp(result, eta_time);
+    ResultFormatter.fuel(result, fuel_remaining);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_44_OFF.ts
+++ b/lib/plugins/generated/Label_44_OFF.ts
@@ -38,11 +38,14 @@ export class Label_44_OFF extends DecoderPlugin {
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
-    ResultFormatter.timestamp(result, month);
-    ResultFormatter.timestamp(result, day);
-    ResultFormatter.timestamp(result, off_time);
-    ResultFormatter.timestamp(result, eta_time);
-    ResultFormatter.currentFuel(result, fuel_remaining);
+    ResultFormatter.month(result, month);
+    ResultFormatter.day(result, day);
+    ResultFormatter.off(result, off_time);
+    ResultFormatter.eta(result, eta_time);
+    ResultFormatter.remainingFuel(result, fuel_remaining);
+    if (data.length > 8) {
+      ResultFormatter.unknownArr(result, data.slice(8));
+    }
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_ON.ts
+++ b/lib/plugins/generated/Label_44_ON.ts
@@ -37,10 +37,13 @@ export class Label_44_ON extends DecoderPlugin {
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
-    ResultFormatter.timestamp(result, month);
-    ResultFormatter.timestamp(result, day);
-    ResultFormatter.timestamp(result, on_time);
-    ResultFormatter.currentFuel(result, fuel_remaining);
+    ResultFormatter.month(result, month);
+    ResultFormatter.day(result, day);
+    ResultFormatter.on(result, on_time);
+    ResultFormatter.remainingFuel(result, fuel_remaining);
+    if (data.length > 7) {
+      ResultFormatter.unknownArr(result, data.slice(7));
+    }
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_ON.ts
+++ b/lib/plugins/generated/Label_44_ON.ts
@@ -1,0 +1,53 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/ON.yaml. Do not edit.
+// Plugin: Label_44_ON
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_ON extends DecoderPlugin {
+  name = "label-44-on";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: ["00ON01","00ON02","00ON03","ON01","ON02","ON03"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "On Runway Report");
+
+    const data = message.text.split(",");
+    if (data.length < 7) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
+    result.raw.position = position;
+    const departure_icao = helpers.airport(data[2]);
+    result.raw.departure_icao = departure_icao;
+    const arrival_icao = helpers.airport(data[3]);
+    result.raw.arrival_icao = arrival_icao;
+    const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
+    result.raw.month = month;
+    const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
+    result.raw.day = day;
+    const on_time = helpers.timestampHhmmss(data[5]);
+    result.raw.on_time = on_time;
+    if (!(["---.-"].includes(data[6]))) {
+      const fuel_remaining = helpers.float(data[6]);
+      result.raw.fuel_remaining = fuel_remaining;
+    }
+    ResultFormatter.position(result, position);
+    ResultFormatter.departureAirport(result, departure_icao);
+    ResultFormatter.arrivalAirport(result, arrival_icao);
+    ResultFormatter.timestamp(result, month);
+    ResultFormatter.timestamp(result, day);
+    ResultFormatter.timestamp(result, on_time);
+    ResultFormatter.fuel(result, fuel_remaining);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_44_ON.ts
+++ b/lib/plugins/generated/Label_44_ON.ts
@@ -25,20 +25,13 @@ export class Label_44_ON extends DecoderPlugin {
       return this.failUnknown(result, message.text, options);
     }
     const position = helpers.coordinateDecimalMinutes(data[1], {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
-    result.raw.position = position;
     const departure_icao = helpers.airport(data[2]);
-    result.raw.departure_icao = departure_icao;
     const arrival_icao = helpers.airport(data[3]);
-    result.raw.arrival_icao = arrival_icao;
     const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
-    result.raw.month = month;
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
-    result.raw.day = day;
     const on_time = helpers.timestampHhmmss(data[5]);
-    result.raw.on_time = on_time;
     if (!(["---.-"].includes(data[6]))) {
       const fuel_remaining = helpers.float(data[6]);
-      result.raw.fuel_remaining = fuel_remaining;
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);

--- a/lib/plugins/generated/Label_44_ON.ts
+++ b/lib/plugins/generated/Label_44_ON.ts
@@ -30,8 +30,9 @@ export class Label_44_ON extends DecoderPlugin {
     const month = helpers.integer(data[4], {"substring_start":0,"substring_length":2});
     const day = helpers.integer(data[4], {"substring_start":2,"substring_length":2});
     const on_time = helpers.timestampHhmmss(data[5]);
+    let fuel_remaining;
     if (!(["---.-"].includes(data[6]))) {
-      const fuel_remaining = helpers.float(data[6]);
+      fuel_remaining = helpers.float(data[6]);
     }
     ResultFormatter.position(result, position);
     ResultFormatter.departureAirport(result, departure_icao);
@@ -39,7 +40,7 @@ export class Label_44_ON extends DecoderPlugin {
     ResultFormatter.timestamp(result, month);
     ResultFormatter.timestamp(result, day);
     ResultFormatter.timestamp(result, on_time);
-    ResultFormatter.fuel(result, fuel_remaining);
+    ResultFormatter.currentFuel(result, fuel_remaining);
     this.setDecodeLevel(result, true, 'full');
     return result;
   }

--- a/lib/plugins/generated/Label_44_POS.ts
+++ b/lib/plugins/generated/Label_44_POS.ts
@@ -28,7 +28,6 @@ export class Label_44_POS extends DecoderPlugin {
     const m = m_match.groups;
     const position = helpers.coordinateDecimalMinutes(m.unsplit_coords, {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
     const flight_level_raw = hatches.parse_flight_level_or_ground(m.flight_level_or_ground, {});
-    result.raw.flight_level_raw = flight_level_raw;
     const altitude = hatches.flight_level_to_altitude_feet(flight_level_raw, {});
     const month = helpers.integer(m.current_date, {"substring_start":0,"substring_length":2});
     const day = helpers.integer(m.current_date, {"substring_start":2,"substring_length":2});
@@ -37,15 +36,15 @@ export class Label_44_POS extends DecoderPlugin {
     let fuel_in_tons;
     if (!(["***","****"].includes(m.fuel_in_tons))) {
       fuel_in_tons = helpers.float(m.fuel_in_tons);
+      result.raw.fuel_in_tons = fuel_in_tons;
     }
     const departure_icao = helpers.airport(m.departure_icao);
     const arrival_icao = helpers.airport(m.arrival_icao);
     ResultFormatter.position(result, position);
-    ResultFormatter.timestamp(result, month);
-    ResultFormatter.timestamp(result, day);
+    ResultFormatter.month(result, month);
+    ResultFormatter.day(result, day);
     ResultFormatter.timestamp(result, timestamp);
-    ResultFormatter.timestamp(result, eta);
-    ResultFormatter.currentFuel(result, fuel_in_tons);
+    ResultFormatter.eta(result, eta);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
     ResultFormatter.altitude(result, altitude);

--- a/lib/plugins/generated/Label_44_POS.ts
+++ b/lib/plugins/generated/Label_44_POS.ts
@@ -1,0 +1,63 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/POS.yaml. Do not edit.
+// Plugin: Label_44_POS
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/44/POS.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_POS extends DecoderPlugin {
+  name = "label-44-pos";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: ["00POS01","00POS02","00POS03","POS01","POS02","POS03"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    const m_match = message.text.match(new RegExp("^.*,(?<unsplit_coords>.*),(?<flight_level_or_ground>.*),(?<departure_icao>.*),(?<arrival_icao>.*),(?<current_date>.*),(?<current_time>.*),(?<eta_time>.*),(?<fuel_in_tons>.*)$"));
+    if (!m_match?.groups) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const m = m_match.groups;
+    const position = helpers.coordinateDecimalMinutes(m.unsplit_coords, {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
+    result.raw.position = position;
+    const flight_level_raw = hatches.parse_flight_level_or_ground(m.flight_level_or_ground, {});
+    result.raw.flight_level_raw = flight_level_raw;
+    const altitude = hatches.flight_level_to_altitude_feet(flight_level_raw, {});
+    result.raw.altitude = altitude;
+    const month = helpers.integer(m.current_date, {"substring_start":0,"substring_length":2});
+    result.raw.month = month;
+    const day = helpers.integer(m.current_date, {"substring_start":2,"substring_length":2});
+    result.raw.day = day;
+    const timestamp = helpers.timestampHhmmss(m.current_time, {"append":"00"});
+    result.raw.timestamp = timestamp;
+    const eta = helpers.timestampHhmmss(m.eta_time, {"append":"00"});
+    result.raw.eta = eta;
+    if (!(["***","****"].includes(m.fuel_in_tons))) {
+      const fuel_in_tons = helpers.float(m.fuel_in_tons);
+      result.raw.fuel_in_tons = fuel_in_tons;
+    }
+    const departure_icao = helpers.airport(m.departure_icao);
+    result.raw.departure_icao = departure_icao;
+    const arrival_icao = helpers.airport(m.arrival_icao);
+    result.raw.arrival_icao = arrival_icao;
+    ResultFormatter.position(result, position);
+    ResultFormatter.timestamp(result, month);
+    ResultFormatter.timestamp(result, day);
+    ResultFormatter.timestamp(result, timestamp);
+    ResultFormatter.timestamp(result, eta);
+    ResultFormatter.fuel(result, fuel_in_tons);
+    ResultFormatter.departureAirport(result, departure_icao);
+    ResultFormatter.arrivalAirport(result, arrival_icao);
+    ResultFormatter.altitude(result, altitude);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_44_POS.ts
+++ b/lib/plugins/generated/Label_44_POS.ts
@@ -34,8 +34,9 @@ export class Label_44_POS extends DecoderPlugin {
     const day = helpers.integer(m.current_date, {"substring_start":2,"substring_length":2});
     const timestamp = helpers.timestampHhmmss(m.current_time, {"append":"00"});
     const eta = helpers.timestampHhmmss(m.eta_time, {"append":"00"});
+    let fuel_in_tons;
     if (!(["***","****"].includes(m.fuel_in_tons))) {
-      const fuel_in_tons = helpers.float(m.fuel_in_tons);
+      fuel_in_tons = helpers.float(m.fuel_in_tons);
     }
     const departure_icao = helpers.airport(m.departure_icao);
     const arrival_icao = helpers.airport(m.arrival_icao);
@@ -44,7 +45,7 @@ export class Label_44_POS extends DecoderPlugin {
     ResultFormatter.timestamp(result, day);
     ResultFormatter.timestamp(result, timestamp);
     ResultFormatter.timestamp(result, eta);
-    ResultFormatter.fuel(result, fuel_in_tons);
+    ResultFormatter.currentFuel(result, fuel_in_tons);
     ResultFormatter.departureAirport(result, departure_icao);
     ResultFormatter.arrivalAirport(result, arrival_icao);
     ResultFormatter.altitude(result, altitude);

--- a/lib/plugins/generated/Label_44_POS.ts
+++ b/lib/plugins/generated/Label_44_POS.ts
@@ -27,27 +27,18 @@ export class Label_44_POS extends DecoderPlugin {
     }
     const m = m_match.groups;
     const position = helpers.coordinateDecimalMinutes(m.unsplit_coords, {"style":"combined","format":"NSDDMM_M_EWDDMM_M"});
-    result.raw.position = position;
     const flight_level_raw = hatches.parse_flight_level_or_ground(m.flight_level_or_ground, {});
     result.raw.flight_level_raw = flight_level_raw;
     const altitude = hatches.flight_level_to_altitude_feet(flight_level_raw, {});
-    result.raw.altitude = altitude;
     const month = helpers.integer(m.current_date, {"substring_start":0,"substring_length":2});
-    result.raw.month = month;
     const day = helpers.integer(m.current_date, {"substring_start":2,"substring_length":2});
-    result.raw.day = day;
     const timestamp = helpers.timestampHhmmss(m.current_time, {"append":"00"});
-    result.raw.timestamp = timestamp;
     const eta = helpers.timestampHhmmss(m.eta_time, {"append":"00"});
-    result.raw.eta = eta;
     if (!(["***","****"].includes(m.fuel_in_tons))) {
       const fuel_in_tons = helpers.float(m.fuel_in_tons);
-      result.raw.fuel_in_tons = fuel_in_tons;
     }
     const departure_icao = helpers.airport(m.departure_icao);
-    result.raw.departure_icao = departure_icao;
     const arrival_icao = helpers.airport(m.arrival_icao);
-    result.raw.arrival_icao = arrival_icao;
     ResultFormatter.position(result, position);
     ResultFormatter.timestamp(result, month);
     ResultFormatter.timestamp(result, day);

--- a/lib/plugins/generated/Label_44_Slash.ts
+++ b/lib/plugins/generated/Label_44_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/44/Slash.yaml. Do not edit.
+// Plugin: Label_44_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_44_Slash extends DecoderPlugin {
+  name = "label-44-slash";
+
+  qualifiers() {
+    return {
+      labels: ["44"],
+      preambles: [" /FB"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Flight Briefing");
+
+    return hatches.label_44_slash_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4A.ts
+++ b/lib/plugins/generated/Label_4A.ts
@@ -20,41 +20,6 @@ export class Label_4A extends DecoderPlugin {
   decode(message: Message, options: Options = {}): DecodeResult {
     const result = this.initResult(message, "Latest New Format");
 
-    const fields = message.text.split(",");
-    if (fields.length === 11) {
-      const timestamp = helpers.timestampHhmmss(fields[0]);
-      result.raw.timestamp = timestamp;
-      const tail = helpers.tailNumber(fields[2], {"strip_chars":"."});
-      result.raw.tail = tail;
-      let callsign;
-      if (fields[3] !== "") {
-        callsign = helpers.callsign(fields[3]);
-        result.raw.callsign = callsign;
-      }
-      const departure_icao = helpers.airport(fields[4]);
-      result.raw.departure_icao = departure_icao;
-      const arrival_icao = helpers.airport(fields[5]);
-      result.raw.arrival_icao = arrival_icao;
-    }
-    else if ((fields.length === 6) && (new RegExp("^[NS]").test(fields[0]))) {
-      const variant_2_result = hatches.label_4a_variant_2_decode(fields, {});
-      result.raw.variant_2_result = variant_2_result;
-    }
-    else if (fields.length === 6) {
-      const timestamp = helpers.timestampHhmmss(fields[0]);
-      result.raw.timestamp = timestamp;
-      const eta = helpers.timestampHhmmss(fields[1]);
-      result.raw.eta = eta;
-      const altitude = helpers.integer(fields[3]);
-      result.raw.altitude = altitude;
-      const position = hatches.label_4a_variant_3_position(fields, {});
-      result.raw.position = position;
-    }
-    else {
-      return this.failUnknown(result, message.text, options);
-    }
-    hatches.label_4a_format(result);
-    this.setDecodeLevel(result, true, 'partial');
-    return result;
+    return hatches.label_4a_dispatch(this, message, result, options);
   }
 }

--- a/lib/plugins/generated/Label_4A.ts
+++ b/lib/plugins/generated/Label_4A.ts
@@ -1,0 +1,59 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4A.yaml. Do not edit.
+// Plugin: Label_4A
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/4A/README.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4A extends DecoderPlugin {
+  name = "label-4a";
+
+  qualifiers() {
+    return {
+      labels: ["4A"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Latest New Format");
+
+    const fields = message.text.split(",");
+    if (fields.length === 11) {
+      const timestamp = helpers.timestampHhmmss(fields[0]);
+      result.raw.timestamp = timestamp;
+      const tail = helpers.tailNumber(fields[2], {"strip_chars":"."});
+      result.raw.tail = tail;
+      if (fields[3] !== "") {
+        const callsign = helpers.callsign(fields[3]);
+        result.raw.callsign = callsign;
+      }
+      const departure_icao = helpers.airport(fields[4]);
+      result.raw.departure_icao = departure_icao;
+      const arrival_icao = helpers.airport(fields[5]);
+      result.raw.arrival_icao = arrival_icao;
+    }
+    else if ((fields.length === 6) && (new RegExp("^[NS]").test(fields[0]))) {
+      const variant_2_result = hatches.label_4a_variant_2_decode(fields, {});
+      result.raw.variant_2_result = variant_2_result;
+    }
+    else if (fields.length === 6) {
+      const timestamp = helpers.timestampHhmmss(fields[0]);
+      result.raw.timestamp = timestamp;
+      const eta = helpers.timestampHhmmss(fields[1]);
+      result.raw.eta = eta;
+      const altitude = helpers.integer(fields[3]);
+      result.raw.altitude = altitude;
+      const position = hatches.label_4a_variant_3_position(fields, {});
+      result.raw.position = position;
+    }
+    else {
+      return this.failUnknown(result, message.text, options);
+    }
+    hatches.label_4a_format(result);
+    this.setDecodeLevel(result, true, 'partial');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_4A.ts
+++ b/lib/plugins/generated/Label_4A.ts
@@ -26,8 +26,9 @@ export class Label_4A extends DecoderPlugin {
       result.raw.timestamp = timestamp;
       const tail = helpers.tailNumber(fields[2], {"strip_chars":"."});
       result.raw.tail = tail;
+      let callsign;
       if (fields[3] !== "") {
-        const callsign = helpers.callsign(fields[3]);
+        callsign = helpers.callsign(fields[3]);
         result.raw.callsign = callsign;
       }
       const departure_icao = helpers.airport(fields[4]);

--- a/lib/plugins/generated/Label_4A_01.ts
+++ b/lib/plugins/generated/Label_4A_01.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4A/01.yaml. Do not edit.
+// Plugin: Label_4A_01
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4A_01 extends DecoderPlugin {
+  name = "label-4a-01";
+
+  qualifiers() {
+    return {
+      labels: ["4A"],
+      preambles: ["01"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Latest New Format");
+
+    return hatches.label_4a_01_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4A_DIS.ts
+++ b/lib/plugins/generated/Label_4A_DIS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4A/DIS.yaml. Do not edit.
+// Plugin: Label_4A_DIS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4A_DIS extends DecoderPlugin {
+  name = "label-4a-dis";
+
+  qualifiers() {
+    return {
+      labels: ["4A"],
+      preambles: ["DIS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Latest New Format");
+
+    return hatches.label_4a_dis_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4A_DOOR.ts
+++ b/lib/plugins/generated/Label_4A_DOOR.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4A/DOOR.yaml. Do not edit.
+// Plugin: Label_4A_DOOR
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4A_DOOR extends DecoderPlugin {
+  name = "label-4a-door";
+
+  qualifiers() {
+    return {
+      labels: ["4A"],
+      preambles: ["DOOR"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Latest New Format");
+
+    return hatches.label_4a_door_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4A_Slash_01.ts
+++ b/lib/plugins/generated/Label_4A_Slash_01.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4A/Slash_01.yaml. Do not edit.
+// Plugin: Label_4A_Slash_01
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4A_Slash_01 extends DecoderPlugin {
+  name = "label-4a-slash-01";
+
+  qualifiers() {
+    return {
+      labels: ["4A"],
+      preambles: ["/01"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Latest New Format");
+
+    return hatches.label_4a_slash_01_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4N.ts
+++ b/lib/plugins/generated/Label_4N.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4N.yaml. Do not edit.
+// Plugin: Label_4N
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4N extends DecoderPlugin {
+  name = "label-4n";
+
+  qualifiers() {
+    return {
+      labels: ["4N"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Airline Defined");
+
+    return hatches.label_4n_decode(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4T_AGFSR.ts
+++ b/lib/plugins/generated/Label_4T_AGFSR.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4T/AGFSR.yaml. Do not edit.
+// Plugin: Label_4T_AGFSR
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4T_AGFSR extends DecoderPlugin {
+  name = "label-4t-agfsr";
+
+  qualifiers() {
+    return {
+      labels: ["4T"],
+      preambles: ["AGFSR"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_4t_agfsr_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_4T_ETA.ts
+++ b/lib/plugins/generated/Label_4T_ETA.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/4T/ETA.yaml. Do not edit.
+// Plugin: Label_4T_ETA
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_4T_ETA extends DecoderPlugin {
+  name = "label-4t-eta";
+
+  qualifiers() {
+    return {
+      labels: ["4T"],
+      preambles: ["ETA"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ETA Report");
+
+    return hatches.label_4t_eta_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_58.ts
+++ b/lib/plugins/generated/Label_58.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/58.yaml. Do not edit.
+// Plugin: Label_58
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_58 extends DecoderPlugin {
+  name = "label-58";
+
+  qualifiers() {
+    return {
+      labels: ["58"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_58_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_5Z_Slash.ts
+++ b/lib/plugins/generated/Label_5Z_Slash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/5Z/Slash.yaml. Do not edit.
+// Plugin: Label_5Z_Slash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_5Z_Slash extends DecoderPlugin {
+  name = "label-5z-slash";
+
+  qualifiers() {
+    return {
+      labels: ["5Z"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Airline Designated Downlink");
+
+    return hatches.label_5z_slash_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_80.ts
+++ b/lib/plugins/generated/Label_80.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/80.yaml. Do not edit.
+// Plugin: Label_80
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_80 extends DecoderPlugin {
+  name = "label-80";
+
+  qualifiers() {
+    return {
+      labels: ["80"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Airline Defined Position Report");
+
+    return hatches.label_80_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_83.ts
+++ b/lib/plugins/generated/Label_83.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/83.yaml. Do not edit.
+// Plugin: Label_83
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_83 extends DecoderPlugin {
+  name = "label-83";
+
+  qualifiers() {
+    return {
+      labels: ["83"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Airline Defined");
+
+    return hatches.label_83_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_8E.ts
+++ b/lib/plugins/generated/Label_8E.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/8E.yaml. Do not edit.
+// Plugin: Label_8E
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_8E extends DecoderPlugin {
+  name = "label-8e";
+
+  qualifiers() {
+    return {
+      labels: ["8E"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ETA Report");
+
+    return hatches.label_8e_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_B6_Forwardslash.ts
+++ b/lib/plugins/generated/Label_B6_Forwardslash.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/B6/Forwardslash.yaml. Do not edit.
+// Plugin: Label_B6_Forwardslash
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_B6_Forwardslash extends DecoderPlugin {
+  name = "label-b6-forwardslash";
+
+  qualifiers() {
+    return {
+      labels: ["B6"],
+      preambles: ["/"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "CPDLC Message");
+
+    return hatches.label_b6_forwardslash_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_ColonComma.ts
+++ b/lib/plugins/generated/Label_ColonComma.ts
@@ -9,7 +9,7 @@ import * as helpers from "@airframes/ads-runtime-ts/helpers";
 import * as hatches from "../escape_hatches";
 
 export class Label_ColonComma extends DecoderPlugin {
-  name = "label-coloncomma";
+  name = "label-colon-comma";
 
   qualifiers() {
     return {

--- a/lib/plugins/generated/Label_ColonComma.ts
+++ b/lib/plugins/generated/Label_ColonComma.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/ColonComma.yaml. Do not edit.
+// Plugin: Label_ColonComma
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/colon_comma/README.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_ColonComma extends DecoderPlugin {
+  name = "label-coloncomma";
+
+  qualifiers() {
+    return {
+      labels: [":;"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Aircraft Transceiver Frequency Change");
+
+    return hatches.label_colon_comma_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_ATIS.ts
+++ b/lib/plugins/generated/Label_H1_ATIS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/ATIS.yaml. Do not edit.
+// Plugin: Label_H1_ATIS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_ATIS extends DecoderPlugin {
+  name = "label-h1-atis";
+
+  qualifiers() {
+    return {
+      labels: ["H1","5Z"],
+      preambles: ["L"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ATIS Subscription");
+
+    return hatches.label_h1_atis_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_EZF.ts
+++ b/lib/plugins/generated/Label_H1_EZF.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/EZF.yaml. Do not edit.
+// Plugin: Label_H1_EZF
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_EZF extends DecoderPlugin {
+  name = "label-h1-ezf";
+
+  qualifiers() {
+    return {
+      labels: ["H1","1M"],
+      preambles: ["EZF"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Load Sheet");
+
+    return hatches.label_h1_ezf_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_FLR.ts
+++ b/lib/plugins/generated/Label_H1_FLR.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/FLR.yaml. Do not edit.
+// Plugin: Label_H1_FLR
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_FLR extends DecoderPlugin {
+  name = "label-h1-flr";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+      preambles: ["FLR","#CFBFLR"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Fault Log Report");
+
+    return hatches.label_h1_flr_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_M_POS.ts
+++ b/lib/plugins/generated/Label_H1_M_POS.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/M_POS.yaml. Do not edit.
+// Plugin: Label_H1_M_POS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_M_POS extends DecoderPlugin {
+  name = "label-h1-m-pos";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "M-Series Periodic Position Report");
+
+    return hatches.label_h1_m_pos_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_OFP.ts
+++ b/lib/plugins/generated/Label_H1_OFP.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/OFP.yaml. Do not edit.
+// Plugin: Label_H1_OFP
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_OFP extends DecoderPlugin {
+  name = "label-h1-ofp";
+
+  qualifiers() {
+    return {
+      labels: ["H1","1M"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Operational Flight Plan");
+
+    return hatches.label_h1_ofp_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_OHMA.ts
+++ b/lib/plugins/generated/Label_H1_OHMA.ts
@@ -21,17 +21,21 @@ export class Label_H1_OHMA extends DecoderPlugin {
   decode(message: Message, options: Options = {}): DecodeResult {
     const result = this.initResult(message, "OHMA Message");
 
-    const ohma_parts = message.text.split("OHMA");
-    if (ohma_parts.length < 2) {
+    try {
+      const ohma_parts = message.text.split("OHMA");
+      if (ohma_parts.length < 2) {
+        return this.failUnknown(result, message.text, options);
+      }
+      const deflated_bytes = helpers.base64ToUint8Array(ohma_parts[1]);
+      const json_bytes = helpers.inflate(deflated_bytes, "raw");
+      const json_text = helpers.textDecode(json_bytes, "utf-8");
+      const ohma = hatches.ohma_unwrap_message(json_text, {});
+      result.raw.ohma = ohma;
+      hatches.ohma_message_item(result);
+      this.setDecodeLevel(result, true, 'full');
+      return result;
+    } catch {
       return this.failUnknown(result, message.text, options);
     }
-    const deflated_bytes = helpers.base64ToUint8Array(ohma_parts[1]);
-    const json_bytes = helpers.inflate(deflated_bytes, "raw");
-    const json_text = helpers.textDecode(json_bytes, "utf-8");
-    const ohma = hatches.ohma_unwrap_message(json_text, {});
-    result.raw.ohma = ohma;
-    hatches.ohma_message_item(result);
-    this.setDecodeLevel(result, true, 'full');
-    return result;
   }
 }

--- a/lib/plugins/generated/Label_H1_OHMA.ts
+++ b/lib/plugins/generated/Label_H1_OHMA.ts
@@ -1,0 +1,37 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/OHMA.yaml. Do not edit.
+// Plugin: Label_H1_OHMA
+// Docs: https://github.com/airframesio/acars-message-documentation/blob/main/research/H1/OHMA.md
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_OHMA extends DecoderPlugin {
+  name = "label-h1-ohma";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+      preambles: ["OHMA","/RTNBOCR.OHMA","#T1B/RTNBOCR.OHMA"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "OHMA Message");
+
+    const ohma_parts = message.text.split("OHMA");
+    if (ohma_parts.length < 2) {
+      return this.failUnknown(result, message.text, options);
+    }
+    const deflated_bytes = helpers.base64ToUint8Array(ohma_parts[1]);
+    const json_bytes = helpers.inflate(deflated_bytes, "raw");
+    const json_text = helpers.textDecode(json_bytes, "utf-8");
+    const ohma = hatches.ohma_unwrap_message(json_text, {});
+    result.raw.ohma = ohma;
+    hatches.ohma_message_item(result);
+    this.setDecodeLevel(result, true, 'full');
+    return result;
+  }
+}

--- a/lib/plugins/generated/Label_H1_Paren.ts
+++ b/lib/plugins/generated/Label_H1_Paren.ts
@@ -18,7 +18,7 @@ export class Label_H1_Paren extends DecoderPlugin {
   }
 
   decode(message: Message, options: Options = {}): DecodeResult {
-    const result = this.initResult(message, "Position Report");
+    const result = this.initResult(message, "Unknown");
 
     return hatches.label_h1_paren_parse(this, message, result, options);
   }

--- a/lib/plugins/generated/Label_H1_Paren.ts
+++ b/lib/plugins/generated/Label_H1_Paren.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/Paren.yaml. Do not edit.
+// Plugin: Label_H1_Paren
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_Paren extends DecoderPlugin {
+  name = "label-h1-paren";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+      preambles: ["("],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_h1_paren_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_StarPOS.ts
+++ b/lib/plugins/generated/Label_H1_StarPOS.ts
@@ -8,7 +8,7 @@ import * as helpers from "@airframes/ads-runtime-ts/helpers";
 import * as hatches from "../escape_hatches";
 
 export class Label_H1_StarPOS extends DecoderPlugin {
-  name = "label-h1-starpos";
+  name = "label-h1-star-pos";
 
   qualifiers() {
     return {

--- a/lib/plugins/generated/Label_H1_StarPOS.ts
+++ b/lib/plugins/generated/Label_H1_StarPOS.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/StarPOS.yaml. Do not edit.
+// Plugin: Label_H1_StarPOS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_StarPOS extends DecoderPlugin {
+  name = "label-h1-starpos";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+      preambles: ["*POS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Position Report");
+
+    return hatches.label_h1_starpos_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H1_WRN.ts
+++ b/lib/plugins/generated/Label_H1_WRN.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H1/WRN.yaml. Do not edit.
+// Plugin: Label_H1_WRN
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H1_WRN extends DecoderPlugin {
+  name = "label-h1-wrn";
+
+  qualifiers() {
+    return {
+      labels: ["H1"],
+      preambles: ["WRN","#CFBWRN"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Warning Message");
+
+    return hatches.label_h1_wrn_parse(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_H2_02E.ts
+++ b/lib/plugins/generated/Label_H2_02E.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/H2/02E.yaml. Do not edit.
+// Plugin: Label_H2_02E
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_H2_02E extends DecoderPlugin {
+  name = "label-h2-02e";
+
+  qualifiers() {
+    return {
+      labels: ["H2"],
+      preambles: ["02E"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Weather Report");
+
+    return hatches.label_h2_02e_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_HX.ts
+++ b/lib/plugins/generated/Label_HX.ts
@@ -1,0 +1,25 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/HX.yaml. Do not edit.
+// Plugin: Label_HX
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_HX extends DecoderPlugin {
+  name = "label-hx";
+
+  qualifiers() {
+    return {
+      labels: ["HX"],
+      preambles: ["RA FMT LOCATION","RA FMT 43"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Undelivered Uplink Report");
+
+    return hatches.label_hx_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_MA.ts
+++ b/lib/plugins/generated/Label_MA.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/MA.yaml. Do not edit.
+// Plugin: Label_MA
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_MA extends DecoderPlugin {
+  name = "label-ma";
+
+  qualifiers() {
+    return {
+      labels: ["MA"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Unknown");
+
+    return hatches.label_ma_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_QP.ts
+++ b/lib/plugins/generated/Label_QP.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/QP.yaml. Do not edit.
+// Plugin: Label_QP
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_QP extends DecoderPlugin {
+  name = "label-qp";
+
+  qualifiers() {
+    return {
+      labels: ["QP"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "OUT Report");
+
+    return hatches.label_qp_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_QQ.ts
+++ b/lib/plugins/generated/Label_QQ.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/QQ.yaml. Do not edit.
+// Plugin: Label_QQ
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_QQ extends DecoderPlugin {
+  name = "label-qq";
+
+  qualifiers() {
+    return {
+      labels: ["QQ"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "OFF Report");
+
+    return hatches.label_qq_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_QR.ts
+++ b/lib/plugins/generated/Label_QR.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/QR.yaml. Do not edit.
+// Plugin: Label_QR
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_QR extends DecoderPlugin {
+  name = "label-qr";
+
+  qualifiers() {
+    return {
+      labels: ["QR"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "ON Report");
+
+    return hatches.label_qr_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_QS.ts
+++ b/lib/plugins/generated/Label_QS.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/QS.yaml. Do not edit.
+// Plugin: Label_QS
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_QS extends DecoderPlugin {
+  name = "label-qs";
+
+  qualifiers() {
+    return {
+      labels: ["QS"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "IN Report");
+
+    return hatches.label_qs_dispatch(this, message, result, options);
+  }
+}

--- a/lib/plugins/generated/Label_SQ.ts
+++ b/lib/plugins/generated/Label_SQ.ts
@@ -1,0 +1,24 @@
+// AUTO-GENERATED from /Users/kevin/Cloud/Dropbox/work/airframes/acars-decoder-typescript/vendor/airframes-decoder/spec/labels/SQ.yaml. Do not edit.
+// Plugin: Label_SQ
+
+import { DecoderPlugin } from "@airframes/ads-runtime-ts";
+import type { DecodeResult, Message, Options } from "@airframes/ads-runtime-ts";
+import { ResultFormatter } from "@airframes/ads-runtime-ts";
+import * as helpers from "@airframes/ads-runtime-ts/helpers";
+import * as hatches from "../escape_hatches";
+
+export class Label_SQ extends DecoderPlugin {
+  name = "label-sq";
+
+  qualifiers() {
+    return {
+      labels: ["SQ"],
+    };
+  }
+
+  decode(message: Message, options: Options = {}): DecodeResult {
+    const result = this.initResult(message, "Ground Station Squitter");
+
+    return hatches.label_sq_dispatch(this, message, result, options);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "scripts": {
     "build": "tsup",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "ads:codegen-build": "cd vendor/airframes-decoder/codegen && npm install && npm run build",
+    "ads:generate": "node vendor/airframes-decoder/codegen/dist/cli.js generate --target ts --spec vendor/airframes-decoder/spec --out lib/plugins/generated",
+    "ads:check": "git diff --exit-code -- lib/plugins/generated || (echo 'lib/plugins/generated is out of date. Run npm run ads:generate and commit.' && exit 1)"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "jest",
     "ads:codegen-build": "cd vendor/airframes-decoder/codegen && npm install && npm run build",
     "ads:generate": "node vendor/airframes-decoder/codegen/dist/cli.js generate --target ts --spec vendor/airframes-decoder/spec --out lib/plugins/generated",
-    "ads:check": "git diff --exit-code -- lib/plugins/generated || (echo 'lib/plugins/generated is out of date. Run npm run ads:generate and commit.' && exit 1)"
+    "ads:check": "git diff --exit-code -- lib/plugins/generated || (echo 'lib/plugins/generated is out of date. Run npm run ads:generate and commit.' && exit 1)",
+    "test:corpus": "jest --testPathPatterns=corpus"
   },
   "engines": {
     "node": ">=18"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,17 @@
   "compilerOptions": {
     "target": "esNext",
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "./dist",
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@airframes/ads-runtime-ts": ["vendor/airframes-decoder/runtimes/typescript/index.ts"],
+      "@airframes/ads-runtime-ts/helpers": ["vendor/airframes-decoder/runtimes/typescript/helpers.ts"],
+      "@airframes/ads-runtime-ts/escape_hatches": ["vendor/airframes-decoder/runtimes/typescript/escape_hatches/index.ts"]
+    }
   },
   "include": ["lib/*.ts", "lib/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vendor"]
 }


### PR DESCRIPTION
## Summary

Integrates [airframesio/acars-decoder](https://github.com/airframesio/acars-decoder) as a git submodule and wires up the codegen toolchain, **without** replacing any hand-written plugin yet. Behavior is identical to master after this PR — every one of the 407 existing tests still passes, byte-for-byte.

This is the foundation PR for Stage 2 of the cross-language ACARS decoder unification. The actual swap (registering generated plugins in `MessageDecoder`) is deferred to a follow-up because the emitter design needs one more pass before swapping is safe (see "What's deferred" below).

## What landed

- **Submodule:** `vendor/airframes-decoder` pinned to `init/ads-v1`.
- **tsconfig path aliases:**
  - `@airframes/ads-runtime-ts` → `vendor/airframes-decoder/runtimes/typescript/index.ts`
  - `@airframes/ads-runtime-ts/helpers` → `vendor/airframes-decoder/runtimes/typescript/helpers.ts`
  - `@airframes/ads-runtime-ts/escape_hatches` → `vendor/airframes-decoder/runtimes/typescript/escape_hatches/index.ts`
- **npm scripts:**
  - `npm run ads:codegen-build` — installs + builds the codegen tool
  - `npm run ads:generate` — emits `lib/plugins/generated/*.ts` from spec YAML
  - `npm run ads:check` — fails if `lib/plugins/generated/` is out-of-date
- **Generated tree committed:** 68 plugins under `lib/plugins/generated/`. Committed (not gitignored) so contributors don't need the codegen toolchain to build/test, and reviewers see exactly what the runtime would use.
- **ESLint excludes:** `vendor/**` and `lib/plugins/generated/**` (avoid linting third-party code and auto-generated source).
- **Jest excludes:** `/vendor/` (skip vendored submodule's own test files).
- **CI workflow:** `.github/workflows/ads-check.yml` calls the central reusable `codegen-check.yml` from airframes-decoder. Single source of CI logic across all three language repos.

## What's deferred (to a follow-up "Stage 2.5" PR)

The emitter currently double-bookkeeps `raw` fields: it auto-emits `result.raw.<fieldName> = value` from the spec's `fields` block AND then formatter calls write to `raw` under formatter-canonical keys (`position`, `altitude`, etc.). The original hand-written plugins only do the latter. Adopting the generated plugins as-is would produce extra `raw` entries that diverge from the existing test expectations.

The fix is in the emitter (`vendor/airframes-decoder/codegen/src/emit-typescript.ts`): track which raw keys the formatter writes and suppress the auto-emit for those keys. Once that lands in airframes-decoder and propagates here via submodule bump, the registration swap is safe.

The original `lib/utils/*.ts` helpers also stay in place until then; once the swap happens, they'll be removed in favor of the vendored copies.

## Test plan

- [x] `npm test` — 407 / 416 tests pass (9 skipped, matches baseline)
- [x] `npm run ads:codegen-build` succeeds
- [x] `npm run ads:generate` produces clean output; no diff vs committed
- [x] tsc resolves the path aliases (verified by running the test suite, which goes through the same module resolution)
- [ ] CI runs the new `ads-check` workflow on this PR (verifies generated tree stays in sync)

## Related

- airframesio/acars-decoder#1 — central spec, codegen, 3 runtimes, 288-sample corpus
- airframesio/acars-decoder-typescript#444 — Buffer.from hotfix (surfaced during centralization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflow to validate ADS-generated code, vendored ADS decoder submodule, and scripts to build/generate/check generated artifacts; updated lint/test/TypeScript tooling to ignore/map vendored/generated code.

* **Refactor**
  * Decoder now routes to the ADS-generated plugin implementations for a broad set of labels.

* **New Features**
  * Dozens of escape-hatch decoder plugins added to expand supported message formats.

* **Tests**
  * Added a shared-corpus parity test suite verifying generated decoder outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->