### PR TITLE
Fix dead missing-preamble guard in Label_2P_FM3/FM4/FM5

### DIFF
--- a/lib/plugins/Label_2P_FM3.test.ts
+++ b/lib/plugins/Label_2P_FM3.test.ts
@@ -88,4 +88,13 @@ describe('Label 2P Preamble FM3', () => {
     expect(decodeResult.formatted.description).toBe('Flight Report');
     expect(decodeResult.formatted.items.length).toBe(0);
   });
+
+  test('missing FM3 preamble', () => {
+    // 7 comma-parts but no `FM3 ` token in parts[0]
+    message.text = '1217,1312,+ 43.77,- 70.18, 39981, 426, 25';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
+  });
 });

--- a/lib/plugins/Label_2P_FM3.ts
+++ b/lib/plugins/Label_2P_FM3.ts
@@ -23,7 +23,7 @@ export class Label_2P_FM3 extends DecoderPlugin {
 
     if (parts.length === 7) {
       const header = parts[0].split('FM3 ');
-      if (header.length == 0) {
+      if (header.length < 2) {
         // can't use preambles, as there can be info before `FM4`
         // so let's check if we want to decode it here
         ResultFormatter.unknown(decodeResult, message.text);

--- a/lib/plugins/Label_2P_FM4.test.ts
+++ b/lib/plugins/Label_2P_FM4.test.ts
@@ -85,4 +85,14 @@ describe('Label_2P Preamble FM4', () => {
     expect(decodeResult.formatted.description).toBe('Flight Report');
     expect(decodeResult.formatted.items.length).toBe(0);
   });
+
+  test('missing FM4 preamble', () => {
+    // 10 comma-parts but no `FM4` token in parts[0]
+    message.text =
+      'KIAD,OMAA,140256,1448, 39.43,- 75.62,23228,328,  43.5, 72500';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
+  });
 });

--- a/lib/plugins/Label_2P_FM4.ts
+++ b/lib/plugins/Label_2P_FM4.ts
@@ -22,7 +22,7 @@ export class Label_2P_FM4 extends DecoderPlugin {
 
     if (parts.length === 10) {
       const header = parts[0].split('FM4');
-      if (header.length == 0) {
+      if (header.length < 2) {
         // can't use preambles, as there can be info before `FM4`
         // so let's check if we want to decode it here
         ResultFormatter.unknown(decodeResult, message.text);

--- a/lib/plugins/Label_2P_FM5.test.ts
+++ b/lib/plugins/Label_2P_FM5.test.ts
@@ -49,4 +49,14 @@ describe('Label_2P Preamble FM5', () => {
     expect(decodeResult.formatted.description).toBe('Flight Report');
     expect(decodeResult.formatted.items.length).toBe(0);
   });
+
+  test('missing FM5 preamble', () => {
+    // 12 comma-parts but no `FM5 ` token in parts[0]
+    message.text =
+      'EIDW,OMAA,113522,1540,+45.147, +23.384,35002,116.24,502 ,36900,ETD23N ,';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
+  });
 });

--- a/lib/plugins/Label_2P_FM5.ts
+++ b/lib/plugins/Label_2P_FM5.ts
@@ -22,7 +22,7 @@ export class Label_2P_FM5 extends DecoderPlugin {
 
     if (parts.length === 12) {
       const header = parts[0].split('FM5 ');
-      if (header.length == 0) {
+      if (header.length < 2) {
         // can't use preambles, as there can be info before `FM4`
         // so let's check if we want to decode it here
         ResultFormatter.unknown(decodeResult, message.text);


### PR DESCRIPTION
## Summary

The three `Label_2P_FM*` plugins try to detect a missing `FM3 ` / `FM4` / `FM5 ` preamble with `if (header.length == 0)` after `parts[0].split('FMx')`. `String.prototype.split` always returns at least one element, so the guard is never true and the missing-preamble branch is dead.

When a `2P` message has the expected comma count but no FMx token in `parts[0]`, `header[1]` is `undefined`:

- **FM3** reads `header[1].length` and throws `TypeError: Cannot read properties of undefined (reading 'length')`. Since `MessageDecoder.decode` does not wrap plugins in try/catch, the whole decode aborts.
- **FM4** / **FM5** pass `undefined` straight to `ResultFormatter.departureAirport`, returning a "decoded" result with an undefined airport.

## Fix

Change the guard to `if (header.length < 2)` so it actually fires when the token is absent, returning the unknown/`none` result the branch already intends.

Added a regression test in each plugin's spec that decodes a message with the right comma count but no FMx preamble; they throw / mis-decode without the change and pass with it.

Fixes #462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed 2P FM3/FM4/FM5 messages that are missing the expected preamble, so they now correctly show as undecoded with no decode level.
  * Expanded validation to catch more incomplete header formats, reducing cases where invalid messages could be partially processed.
  * Added test coverage for missing preamble scenarios across FM3, FM4, and FM5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->