### PR TITLE
fix(flight_plan_utils): preserve full runway in addCompanyRoute when ')' is missing

### DIFF
--- a/lib/utils/flight_plan_utils.test.ts
+++ b/lib/utils/flight_plan_utils.test.ts
@@ -26,3 +26,41 @@ describe('FlightPlanUtils.parseHeader', () => {
     expect(decodeResult.formatted.items[1].label).toBe('Aircraft Route');
   });
 });
+
+describe('FlightPlanUtils.processFlightPlan company route', () => {
+  const makeDecodeResult = (): DecodeResult => ({
+    decoded: true,
+    decoder: { name: 'test', type: 'pattern-match', decodeLevel: 'full' },
+    formatted: { description: 'Test', items: [] },
+    raw: {},
+    remaining: {},
+  });
+
+  test('preserves full runway when closing paren is present', () => {
+    const decodeResult = makeDecodeResult();
+
+    FlightPlanUtils.processFlightPlan(decodeResult, [
+      'RP',
+      'CR',
+      'ABC(RW26).WPT1.WPT2',
+    ]);
+
+    expect(decodeResult.raw.company_route.name).toBe('ABC');
+    expect(decodeResult.raw.company_route.runway).toBe('RW26');
+  });
+
+  test('does not drop the last runway character when closing paren is missing', () => {
+    const decodeResult = makeDecodeResult();
+
+    // Malformed input: '(' without a matching ')' before the first '.'.
+    FlightPlanUtils.processFlightPlan(decodeResult, [
+      'RP',
+      'CR',
+      'ABC(RW26.WPT1.WPT2',
+    ]);
+
+    expect(decodeResult.raw.company_route.name).toBe('ABC');
+    // Regression for issue: previously slice(4, -1) truncated to 'RW2'.
+    expect(decodeResult.raw.company_route.runway).toBe('RW26');
+  });
+});

--- a/lib/utils/flight_plan_utils.ts
+++ b/lib/utils/flight_plan_utils.ts
@@ -179,7 +179,14 @@ function addCompanyRoute(decodeResult: DecodeResult, value: string) {
     name = segments[0];
   } else {
     name = segments[0].slice(0, parens_idx);
-    runway = segments[0].slice(parens_idx + 1, segments[0].indexOf(')'));
+    const close_paren_idx = segments[0].indexOf(')');
+    // When ')' is missing, indexOf returns -1, which slice() would
+    // interpret as "count from the end", silently dropping the final
+    // character. Fall back to the end of the segment to preserve data.
+    runway = segments[0].slice(
+      parens_idx + 1,
+      close_paren_idx === -1 ? undefined : close_paren_idx,
+    );
   }
   let waypoints;
   if (segments.length > 1) {


### PR DESCRIPTION
## Summary

Fixes #478.

`addCompanyRoute` computed the `runway` substring using `segments[0].indexOf(')')` as the **end index** of `String.prototype.slice()`. When the input has an opening `(` but no closing `)` before the first `.`, `indexOf(')')` returns `-1`, which `slice()` interprets as "count from the end". The result: the final runway character was **silently dropped**.

Example (from the issue):

| Input | Before | After |
| --- | --- | --- |
| `ABC(RW26.WPT1.WPT2` | runway = `RW2` (the `6` is lost) | runway = `RW26` |

## The fix

When the closing paren is absent, fall back to the end of the segment (`undefined` end index) instead of `-1`, so malformed input no longer loses its last character:

```ts
const close_paren_idx = segments[0].indexOf(')');
runway = segments[0].slice(
  parens_idx + 1,
  close_paren_idx === -1 ? undefined : close_paren_idx,
);
```

This is the same class of quiet-corruption bug as the already-filed #466 (`addRunway`), in this sibling helper.

## Tests

Added two regression tests to `lib/utils/flight_plan_utils.test.ts` covering both the well-formed (`ABC(RW26)`) and malformed (`ABC(RW26.`) cases, exercising the public `processFlightPlan` → `CR` code path.

- Full suite: **456 passed, 9 skipped** (pre-existing skips), 97 suites
- `eslint` on both changed files: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved company route parsing to preserve complete runway identifiers when route strings include or omit a closing parenthesis.

* **Tests**
  * Added regression coverage for runway parsing with both properly closed and incomplete route strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->