### PR TITLE
fix(result_formatter): preserve full hex for checksums wider than 16 bits

### DIFF
--- a/lib/utils/result_formatter.test.ts
+++ b/lib/utils/result_formatter.test.ts
@@ -1,0 +1,64 @@
+import { DecodeResult } from '../DecoderPluginInterface';
+import { ResultFormatter } from './result_formatter';
+
+function makeDecodeResult(): DecodeResult {
+  return {
+    decoded: true,
+    decoder: { name: 'test', type: 'pattern-match', decodeLevel: 'full' },
+    formatted: { description: 'Test', items: [] },
+    raw: {},
+    remaining: {},
+  };
+}
+
+describe('ResultFormatter.checksum', () => {
+  test('formats 16-bit checksum with 4-hex-digit padding', () => {
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0x1234);
+    expect(dr.raw.checksum).toBe(0x1234);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.type).toBe('message_checksum');
+    expect(item.value).toBe('0x1234');
+  });
+
+  test('pads small values to at least 4 hex digits', () => {
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0x003b);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.value).toBe('0x003b');
+  });
+
+  test('preserves full hex for 20-bit checksum (no truncation)', () => {
+    // 0xaff5c is 5 hex digits — old code truncated to 0xff5c
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0xaff5c);
+    expect(dr.raw.checksum).toBe(0xaff5c);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.value).toBe('0xaff5c');
+  });
+
+  test('preserves full hex for 32-bit checksum (no truncation)', () => {
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0x123456);
+    expect(dr.raw.checksum).toBe(0x123456);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.value).toBe('0x123456');
+  });
+
+  test('displays large 32-bit CRC without sign artifacts', () => {
+    // 0xDEADBEEF has the top bit set; toString(16) on a signed int would
+    // produce a negative string. >>> 0 coerces to unsigned first.
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0xdeadbeef);
+    expect(dr.raw.checksum).toBe(0xdeadbeef);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.value).toBe('0xdeadbeef');
+  });
+
+  test('pads 12-bit value to 4 digits', () => {
+    const dr = makeDecodeResult();
+    ResultFormatter.checksum(dr, 0xabc);
+    const item = dr.formatted.items[dr.formatted.items.length - 1];
+    expect(item.value).toBe('0x0abc');
+  });
+});

--- a/lib/utils/result_formatter.test.ts
+++ b/lib/utils/result_formatter.test.ts
@@ -37,7 +37,7 @@ describe('ResultFormatter.checksum', () => {
     expect(item.value).toBe('0xaff5c');
   });
 
-  test('preserves full hex for 32-bit checksum (no truncation)', () => {
+  test('preserves full hex for 24-bit checksum (no truncation)', () => {
     const dr = makeDecodeResult();
     ResultFormatter.checksum(dr, 0x123456);
     expect(dr.raw.checksum).toBe(0x123456);
@@ -46,11 +46,12 @@ describe('ResultFormatter.checksum', () => {
   });
 
   test('displays large 32-bit CRC without sign artifacts', () => {
-    // 0xDEADBEEF has the top bit set; toString(16) on a signed int would
-    // produce a negative string. >>> 0 coerces to unsigned first.
+    // 0xDEADBEEF has the top bit set; pass the signed int32 representation
+    // (-559038737) to actually exercise the >>> 0 unsigned coercion path.
     const dr = makeDecodeResult();
-    ResultFormatter.checksum(dr, 0xdeadbeef);
-    expect(dr.raw.checksum).toBe(0xdeadbeef);
+    const signedChecksum = -559038737; // int32 representation of 0xdeadbeef
+    ResultFormatter.checksum(dr, signedChecksum);
+    expect(dr.raw.checksum).toBe(signedChecksum);
     const item = dr.formatted.items[dr.formatted.items.length - 1];
     expect(item.value).toBe('0xdeadbeef');
   });

--- a/lib/utils/result_formatter.ts
+++ b/lib/utils/result_formatter.ts
@@ -294,7 +294,7 @@ export class ResultFormatter {
       type: 'message_checksum',
       code: 'CHECKSUM',
       label: 'Message Checksum',
-      value: '0x' + ('0000' + decodeResult.raw.checksum.toString(16)).slice(-4),
+      value: '0x' + (decodeResult.raw.checksum >>> 0).toString(16).padStart(4, '0'),
     });
   }
 

--- a/lib/utils/result_formatter.ts
+++ b/lib/utils/result_formatter.ts
@@ -294,7 +294,8 @@ export class ResultFormatter {
       type: 'message_checksum',
       code: 'CHECKSUM',
       label: 'Message Checksum',
-      value: '0x' + (decodeResult.raw.checksum >>> 0).toString(16).padStart(4, '0'),
+      value:
+        '0x' + (decodeResult.raw.checksum >>> 0).toString(16).padStart(4, '0'),
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #484

`ResultFormatter.checksum` used `('0000' + hex).slice(-4)` which **silently truncates** any checksum wider than 16 bits to its last 4 hex digits. For example:

- `0xAFF5C` → displayed as `0xFF5C` (wrong)
- `0x123456` → displayed as `0x3456` (wrong)
- `0xDEADBEEF` → displayed as `0xBEEF` (wrong)

The `raw.checksum` value is stored correctly; only the `formatted.items` entry (what downstream consumers render) is corrupted.

## Fix

Replaced the truncating pad-and-slice with:

```ts
value: '0x' + (decodeResult.raw.checksum >>> 0).toString(16).padStart(4, '0'),
```

- `padStart(4, '0')` pads values < 0x1000 to 4 hex digits (preserving prior behaviour)
- No truncation for wider values — full hex is always shown
- `>>> 0` coerces to unsigned, avoiding negative-hex display for 32-bit CRCs whose top bit is set (companion to #458)

## Test coverage

Added `lib/utils/result_formatter.test.ts` with 6 unit tests:

| Test | Input | Expected output |
|------|-------|-----------------|
| 16-bit round-trip | `0x1234` | `0x1234` |
| Small value padding | `0x003b` | `0x003b` |
| 20-bit no truncation | `0xaff5c` | `0xaff5c` |
| 24-bit no truncation | `0x123456` | `0x123456` |
| 32-bit unsigned CRC | `0xdeadbeef` | `0xdeadbeef` |
| 12-bit padding | `0xabc` | `0x0abc` |

## Verification

```
Test Suites: 98 passed, 98 total
Tests:       460 passed, 9 skipped (pre-existing), 469 total
```

Full suite green. No regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum display to consistently use unsigned hexadecimal values.
  * Preserved full-width values for larger checksums without truncation or sign-related formatting issues.
  * Ensured smaller checksum values are padded to at least four hexadecimal digits.

* **Tests**
  * Added coverage for checksum formatting across 12-bit, 16-bit, 20-bit, 24-bit, and 32-bit values.
  * Verified numeric checksum storage and correctly formatted checksum messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->