### PR TITLE
fix(Label_H1_ATIS): populate sequence_number from captured seq group

### DIFF
--- a/lib/plugins/Label_H1_ATIS.test.ts
+++ b/lib/plugins/Label_H1_ATIS.test.ts
@@ -32,6 +32,7 @@ describe('Label H1 ATIS Subscription', () => {
     expect(decodeResult.raw.arrival_icao).toBe('KSFO');
     expect(decodeResult.raw.atis_code).toBe('030');
     expect(decodeResult.raw.checksum).toBe(0xaff5c);
+    expect(decodeResult.raw.sequence_number).toBe(95);
   });
 
   test('decodes OERK ATIS subscription', () => {

--- a/lib/plugins/Label_H1_ATIS.ts
+++ b/lib/plugins/Label_H1_ATIS.ts
@@ -43,6 +43,7 @@ export class Label_H1_ATIS extends DecoderPlugin {
 
     ResultFormatter.flightNumber(decodeResult, flight);
     ResultFormatter.arrivalAirport(decodeResult, facility);
+    ResultFormatter.sequenceNumber(decodeResult, parseInt(seq, 10));
 
     decodeResult.raw.atis_code = code;
     decodeResult.formatted.items.push({


### PR DESCRIPTION
## Summary

Closes #504.

The regex in Label_H1_ATIS.decode() captures a 2-digit sequence number in group 1 but the value was never passed through to ResultFormatter.sequenceNumber(). This meant aw.sequence_number was always undefined, preventing downstream dedup of repeated ATIS deliveries.

## Changes

- lib/plugins/Label_H1_ATIS.ts — call ResultFormatter.sequenceNumber(decodeResult, parseInt(seq, 10)) after the existing lightNumber/rrivalAirport calls
- lib/plugins/Label_H1_ATIS.test.ts — assert aw.sequence_number === 95 on the KSFO test case

## Test

`	s
expect(decodeResult.raw.sequence_number).toBe(95);
`

All existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ATIS messages now correctly include their sequence number in decoded results.
* **Tests**
  * Added coverage to verify sequence numbers are decoded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->