### PR TITLE
feat(Label_16_AUTPOS): register plugin in official exports and MessageDecoder

### DIFF
--- a/lib/MessageDecoder.ts
+++ b/lib/MessageDecoder.ts
@@ -24,6 +24,7 @@ const pluginClasses = [
   Plugins.Label_13Through18_Slash,
   Plugins.Label_15,
   Plugins.Label_15_FST,
+  Plugins.Label_16_AUTPOS,
   Plugins.Label_16_Honeywell,
   Plugins.Label_16_N_Space,
   Plugins.Label_16_POSA1,

--- a/lib/plugins/official.ts
+++ b/lib/plugins/official.ts
@@ -9,6 +9,7 @@ export * from './Label_12_POS';
 export * from './Label_13Through18_Slash';
 export * from './Label_15';
 export * from './Label_15_FST';
+export * from './Label_16_AUTPOS';
 export * from './Label_16_Honeywell';
 export * from './Label_16_N_Space';
 export * from './Label_16_POSA1';


### PR DESCRIPTION
## Summary

`Label_16_AUTPOS` is a complete, tested decoder for ACARS Label 16 `/AUTPOS/` position reports — but it was never registered in the plugin system. AUTPOS messages fell through to other Label-16 variants that don't match, reporting "Not Decoded" in every install of `@airframes/acars-decoder`.

This PR adds the missing `export * from './Label_16_AUTPOS'` in `official.ts` and the `Plugins.Label_16_AUTPOS` entry in `MessageDecoder.ts`'s `pluginClasses` array.

## Changes

- `lib/plugins/official.ts` — add `export * from './Label_16_AUTPOS'` (alphabetical position among Label_16 variants)
- `lib/MessageDecoder.ts` — add `Plugins.Label_16_AUTPOS` to `pluginClasses` array (matching position of other Label_16 variants)

## Test

- `npx jest Label_16_AUTPOS` — 4/4 tests pass
- Existing test suite in `Label_16_AUTPOS.test.ts` already covers decoding redacted and full-value messages

Fixes #499


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding Label 16 AUTPOS messages.
  * Made the Label 16 AUTPOS plugin available through the official plugin exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->