### PR TITLE
fix(Label_QQ): guard groundspeed on the actual 45..48 field, not remaining.text

### DIFF
--- a/lib/plugins/Label_QQ.test.ts
+++ b/lib/plugins/Label_QQ.test.ts
@@ -117,6 +117,29 @@ describe('Label QQ', () => {
     expect(decodeResult.formatted.items[2].value).toBe('00:58:00');
   });
 
+  test('decodes Label QQ groundspeed placeholder after non-placeholder field (#507)', () => {
+    // Variant 1 layout but field 45..48 is '---' while 42..45 is '028'.
+    // Previously the guard tested remaining.text (the 42..45 field), so this
+    // message stored NaN groundspeed and rendered "NaN knots".
+    message.text = 'KLGBKLAX0004\r\n001FE07000444N3349.8W11810.1028---0009';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(true);
+    expect(decodeResult.decoder.decodeLevel).toBe('partial');
+    expect(decodeResult.decoder.name).toBe('label-qq');
+    expect(decodeResult.raw.departure_icao).toBe('KLGB');
+    expect(decodeResult.raw.arrival_icao).toBe('KLAX');
+    expect(decodeResult.raw.position.latitude).toBe(33.83);
+    expect(decodeResult.raw.position.longitude).toBe(-118.16833333333334);
+    expect(decodeResult.raw.groundspeed).toBeUndefined();
+    expect(Number.isNaN(decodeResult.raw.groundspeed)).toBe(false);
+    expect(decodeResult.remaining.text).toBe('028,---,0009');
+    expect(decodeResult.formatted.items.length).toBe(4);
+    expect(
+      decodeResult.formatted.items.some((item) => item.code === 'GSPD'),
+    ).toBe(false);
+  });
+
   // disabled because all messages should decode
   test.skip('decodes Label QQ <invalid>', () => {
     message.text = 'QQ Bogus message';

--- a/lib/plugins/Label_QQ.ts
+++ b/lib/plugins/Label_QQ.ts
@@ -43,13 +43,11 @@ export class Label_QQ extends DecoderPlugin {
       ResultFormatter.unknown(decodeResult, message.text.substring(42, 45));
       ResultFormatter.position(decodeResult, pos);
 
-      if (decodeResult.remaining.text !== '---') {
-        ResultFormatter.groundspeed(
-          decodeResult,
-          Number(message.text.substring(45, 48)),
-        );
+      const gsField = message.text.substring(45, 48);
+      if (decodeResult.remaining.text !== '---' && gsField !== '---') {
+        ResultFormatter.groundspeed(decodeResult, Number(gsField));
       } else {
-        ResultFormatter.unknown(decodeResult, message.text.substring(45, 48));
+        ResultFormatter.unknown(decodeResult, gsField);
       }
       ResultFormatter.unknown(decodeResult, message.text.substring(48));
     } else {


### PR DESCRIPTION
Fixes #507.

## Problem

`Label_QQ.decode()` guards the groundspeed field by testing `decodeResult.remaining.text !== '---'`, but at that point `remaining.text` holds the *previous* unknown field (`substring(42, 45)`), not the groundspeed field (`substring(45, 48)`). When 45..48 is `---` but 42..45 is not (e.g. `...028---0009`), the guard passes and `Number('---')` stores a `NaN` groundspeed, rendering `"NaN knots"`.

## Fix

Read the groundspeed field into a local (`gsField`) and include it in the guard:

```ts
const gsField = message.text.substring(45, 48);
if (decodeResult.remaining.text !== '---' && gsField !== '---') {
  ResultFormatter.groundspeed(decodeResult, Number(gsField));
} else {
  ResultFormatter.unknown(decodeResult, gsField);
}
```

Note: I intentionally kept the existing `remaining.text` check rather than replacing it with a check on `gsField` alone. The variant 2 fixture (`...10.1---0200009`) asserts that when the 42..45 field is `---`, the following `020` is recorded as unknown rather than decoded as a 20-knot groundspeed. Guarding on `gsField` alone would change that established behavior; this version preserves both existing fixtures while eliminating the NaN path.

## Tests

- Added a regression test for the `028---` split: no `groundspeed` in `raw`, no `GSPD` formatted item, field recorded as unknown.
- All existing Label_QQ tests unchanged and passing.
- Full suite: 100 suites, 469 passed, 9 skipped (pre-existing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Label QQ messages with unavailable groundspeed data.
  * Messages now decode successfully while preserving position, route, and remaining fields.
  * Unavailable groundspeed values are omitted instead of being displayed incorrectly.

* **Tests**
  * Added regression coverage for messages containing unavailable groundspeed fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->