### PR TITLE
fix(Label_4A_DIS): guard against comma-less DIS payloads (#493)

### DIFF
--- a/lib/plugins/Label_4A_DIS.test.ts
+++ b/lib/plugins/Label_4A_DIS.test.ts
@@ -39,15 +39,23 @@ describe('Label 4A preamble DIS', () => {
     expect(decodeResult.formatted.items[2].value).toBe('@HOLD CNX');
   });
 
-  // disabled because all messages should decode
-  test.skip('decodes Label 4A_DIS <invalid>', () => {
-    message.text = '4A_DIS Bogus message';
+  test('does not throw on comma-less DIS payload', () => {
+    message.text = 'DIS';
     const decodeResult = plugin.decode(message);
 
     expect(decodeResult.decoded).toBe(false);
     expect(decodeResult.decoder.decodeLevel).toBe('none');
     expect(decodeResult.decoder.name).toBe('label-4a-dis');
     expect(decodeResult.formatted.description).toBe('Latest New Format');
+    expect(decodeResult.formatted.items.length).toBe(0);
+  });
+
+  test('does not throw on DIS with empty field after comma', () => {
+    message.text = 'DIS,';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
     expect(decodeResult.formatted.items.length).toBe(0);
   });
 });

--- a/lib/plugins/Label_4A_DIS.test.ts
+++ b/lib/plugins/Label_4A_DIS.test.ts
@@ -58,4 +58,22 @@ describe('Label 4A preamble DIS', () => {
     expect(decodeResult.decoder.decodeLevel).toBe('none');
     expect(decodeResult.formatted.items.length).toBe(0);
   });
+
+  test('does not decode DIS payload without comma', () => {
+    message.text = 'DIS01';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
+    expect(decodeResult.formatted.items.length).toBe(0);
+  });
+
+  test('does not decode DIS payload without callsign', () => {
+    message.text = 'DIS01,190009';
+    const decodeResult = plugin.decode(message);
+
+    expect(decodeResult.decoded).toBe(false);
+    expect(decodeResult.decoder.decodeLevel).toBe('none');
+    expect(decodeResult.formatted.items.length).toBe(0);
+  });
 });

--- a/lib/plugins/Label_4A_DIS.ts
+++ b/lib/plugins/Label_4A_DIS.ts
@@ -16,8 +16,14 @@ export class Label_4A_DIS extends DecoderPlugin {
   decode(message: Message, options: Options = {}): DecodeResult {
     const decodeResult = this.initResult(message, 'Latest New Format');
 
-    decodeResult.decoded = true;
     const fields = message.text.split(',');
+    if (fields.length < 2 || !fields[1] || fields[1].length < 3) {
+      decodeResult.decoded = false;
+      this.setDecodeLevel(decodeResult, decodeResult.decoded);
+      return decodeResult;
+    }
+
+    decodeResult.decoded = true;
     ResultFormatter.timestamp(
       decodeResult,
       DateTimeUtils.convertHHMMSSToTod(fields[1].substring(2) + '00'),

--- a/lib/plugins/Label_4A_DIS.ts
+++ b/lib/plugins/Label_4A_DIS.ts
@@ -17,7 +17,7 @@ export class Label_4A_DIS extends DecoderPlugin {
     const decodeResult = this.initResult(message, 'Latest New Format');
 
     const fields = message.text.split(',');
-    if (fields.length < 2 || !fields[1] || fields[1].length < 3) {
+    if (fields.length < 3 || !fields[1] || fields[1].length < 3 || !fields[2]) {
       decodeResult.decoded = false;
       this.setDecodeLevel(decodeResult, decodeResult.decoded);
       return decodeResult;


### PR DESCRIPTION
## Problem

`Label_4A_DIS.decode` splits `message.text` on `,` then unconditionally calls `fields[1].substring(2)`. A comma-less DIS payload (truncated header, DIS-only marker) makes `fields[1]` undefined, throwing `TypeError: Cannot read properties of undefined (reading 'substring')` and aborting the entire `MessageDecoder.decode()`.

## Fix

Early-return with `decoded: false` when `fields.length < 2` or `fields[1]` is too short for the timestamp parse. This mirrors the defensive pattern used in other label plugins (e.g. `Label_4T_ETA`, `Label_5Z_Slash`).

## Tests

- Existing fixture (`DIS01,190009,WEN3140,@HOLD CNX`) still passes
- New: `"DIS"` (no comma) → `decoded: false`, no throw
- New: `"DIS,"` (empty field after comma) → `decoded: false`, no throw
- Full suite: 483 passed, 8 skipped, 0 failed

Closes #493


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed `DIS` messages.
  - Invalid or incomplete input now fails safely without throwing errors.
  - Empty or missing fields produce a clear undecoded result with no items.
  - Inputs with missing separators, short identifiers, or absent message content are now rejected consistently.
  - Valid `DIS` messages continue to decode with their existing timestamps, callsigns, and text formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->